### PR TITLE
BarotropicQGQL module

### DIFF
--- a/examples/barotropicqgql_forcedbetaturb.jl
+++ b/examples/barotropicqgql_forcedbetaturb.jl
@@ -1,0 +1,195 @@
+using PyPlot,
+  JLD2,
+  Statistics,
+  Printf,
+  Random,
+  FourierFlows
+
+import GeophysicalFlows.BarotropicQGQL
+import GeophysicalFlows.BarotropicQGQL: energy, enstrophy
+
+import FFTW: irfft
+import Statistics: mean
+
+# Numerical parameters and time-stepping parameters
+nx = 256       # 2D resolution = nx^2
+stepper = "FilteredRK4"   # timestepper
+dt  = 0.01     # timestep
+nsteps = 20000 # total number of time-steps
+nsubs  = 500   # number of time-steps for plotting
+               # (nsteps must be multiple of nsubs)
+
+# Physical parameters
+Lx  = 2π       # domain size
+nu  = 0e-05    # viscosity
+nnu = 1        # viscosity order
+beta = 15.0    # planetary PV gradient
+mu   = 0.02    # bottom drag
+
+
+# Forcing
+kf, dkf = 12.0, 2.0     # forcing wavenumber and width of
+                        # forcing ring in wavenumber space
+σ = 0.005               # energy input rate by the forcing
+gr  = TwoDGrid(nx, Lx)
+force2k = @. exp(-(sqrt(gr.KKrsq)-kf)^2/(2*dkf^2))
+force2k[gr.KKrsq .< 2.0^2 ] .= 0
+force2k[gr.KKrsq .> 20.0^2 ] .= 0
+force2k[gr.Kr.<2π/Lx] .= 0
+σ0 = FourierFlows.parsevalsum(force2k.*gr.invKKrsq/2.0, gr)/(gr.Lx*gr.Ly)
+force2k .= σ/σ0 * force2k  # normalization so that forcing injects
+                           # energy ε per domain area per unit time
+
+# reset of the random number generator for reproducibility
+Random.seed!(1234)
+
+# the function that updates the forcing realization
+function calcF!(Fh, t, s, v, p, g)
+  ξ = exp.(2π*im*rand(Float64, size(s.sol)))/sqrt(s.dt)
+  ξ[1, 1] = 0
+  @. Fh = ξ*sqrt(force2k)
+  Fh[abs.(g.Kr).==0] .= 0
+  nothing
+end
+
+# Initialize problem
+prob = BarotropicQGQL.ForcedProblem(nx=nx, Lx=Lx, beta=beta, nu=nu, nnu=nnu,
+                                  mu=mu, dt=dt, stepper=stepper, calcF=calcF!)
+s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts
+
+
+# Files
+filepath = "."
+filename = joinpath(filepath, "forcedbetaturbQL.jld2")
+
+# File management
+if isfile(filename); rm(filename); end
+
+ξ = exp.(2π*im*rand(Float64, size(s.sol)))
+ζ0h = sqrt.(force2k/(2*mu)).*ξ
+ζ0h[:, 1] .= 0
+ ζ0 = irfft(ζ0h, g.nx)
+
+# Zero initial condition
+BarotropicQGQL.set_zeta!(prob, 0*ζ0)
+
+function zetaMean(prob)
+    sol = prob.state.sol
+    sol[1, :]
+end
+
+# Create Diagnostic -- "energy" and "enstrophy" are functions imported at the top.
+E = Diagnostic(energy, prob; nsteps=nsteps)
+Z = Diagnostic(enstrophy, prob; nsteps=nsteps)
+zMean = Diagnostic(zetaMean, prob; nsteps=nsteps, freq=10)
+diags = [E, Z, zMean] # A list of Diagnostics types passed to "stepforward!" will
+# be updated every timestep. They should be efficient to calculate and
+# have a small memory footprint. (For example, the domain-integrated kinetic
+# energy is just a single number for each timestep).
+
+# Create Output
+get_sol(prob) = prob.vars.sol # extracts the Fourier-transformed solution
+get_u(prob) = irfft(im*g.Lr.*g.invKKrsq.*prob.vars.sol, g.nx)
+out = Output(prob, filename, (:sol, get_sol), (:u, get_u))
+
+
+function plot_output(prob, fig, axs; drawcolorbar=false)
+  # Plot the vorticity and streamfunction fields as well as the zonal mean
+  # vorticity and the zonal mean zonal velocity.
+
+  s, v, p, g = prob.state, prob.vars, prob.params, prob.grid
+  BarotropicQGQL.updatevars!(prob)
+
+  sca(axs[1])
+  cla()
+  pcolormesh(g.X, g.Y, v.zeta .+ v.Zeta)
+  axis("square")
+  xticks(-3:1:3)
+  yticks(-3:1:3)
+  title(L"vorticity $\zeta = \partial_x v - \partial_y u$")
+  if drawcolorbar==true
+    colorbar()
+  end
+
+  sca(axs[2])
+  cla()
+  pcolormesh(g.X, g.Y, v.psi)
+  axis("square")
+  xticks(-3:1:3)
+  yticks(-3:1:3)
+  title(L"streamfunction $\psi$")
+  if drawcolorbar==true
+    colorbar()
+  end
+
+  sca(axs[3])
+  cla()
+  plot(transpose(mean(v.Zeta, dims=1)), g.Y[1,:])
+  plot(0*g.Y[1,:], g.Y[1,:], "k--")
+  yticks(-3:1:3)
+  ylim(-Lx/2, Lx/2)
+  xlim(-4, 4)
+  title(L"zonal mean $\zeta$")
+
+  sca(axs[4])
+  cla()
+  plot(mean(transpose(v.U), dims=2), g.Y[1,:])
+  plot(0*g.Y[1,:], g.Y[1,:], "k--")
+  yticks(-3:1:3)
+  ylim(-Lx/2, Lx/2)
+  xlim(-0.7, 0.7)
+  title(L"zonal mean $u$")
+
+  sca(axs[5])
+  cla()
+  plot(mu*E.time[1:E.prob.step], E.data[1:prob.step], label="energy")
+  xlabel(L"\mu t")
+  legend()
+
+  sca(axs[6])
+  cla()
+  plot(mu*Z.time[1:E.prob.step], Z.data[1:prob.step], label="enstrophy")
+  xlabel(L"\mu t")
+  legend()
+
+  pause(0.001)
+end
+
+fig, axs = subplots(ncols=3, nrows=2, figsize=(14, 8))
+plot_output(prob, fig, axs; drawcolorbar=false)
+
+# Step forward
+startwalltime = time()
+
+while prob.step < nsteps
+  stepforward!(prob, diags, nsubs)
+
+  BarotropicQGQL.updatevars!(prob)
+
+  # Message
+  cfl = prob.ts.dt*maximum([maximum(v.v)/g.dy, maximum(v.u+v.U)/g.dx])
+  log = @sprintf("step: %04d, t: %d, cfl: %.2f, E: %.4f, Q: %.4f, τ: %.2f min",
+    prob.step, prob.t, cfl, E.value, Z.value,
+    (time()-startwalltime)/60)
+
+  println(log)
+
+  plot_output(prob, fig, axs; drawcolorbar=false)
+end
+
+# how long did it take?
+println((time()-startwalltime))
+
+plot_output(prob, fig, axs; drawcolorbar=false)
+
+
+UM = zeros(g.ny, length(zMean.time))
+for in = 1:length(zMean.time)
+    UM[:, in] = real(ifft(im*g.Lr[1, :].*zMean[in].*g.invKKrsq[1, :]))
+end
+figure(2); pcolormesh(zMean.time, g.y.', UM)
+
+
+# save the figure as png
+# savename = @sprintf("%s_%09d.png", joinpath(plotpath, plotname), prob.step)
+# savefig(savename)

--- a/examples/barotropicqgql_forcedbetaturb.jl
+++ b/examples/barotropicqgql_forcedbetaturb.jl
@@ -65,13 +65,8 @@ filename = joinpath(filepath, "forcedbetaturbQL.jld2")
 # File management
 if isfile(filename); rm(filename); end
 
-ξ = exp.(2π*im*rand(Float64, size(s.sol)))
-ζ0h = sqrt.(force2k/(2*mu)).*ξ
-ζ0h[:, 1] .= 0
- ζ0 = irfft(ζ0h, g.nx)
-
 # Zero initial condition
-BarotropicQGQL.set_zeta!(prob, 0*ζ0)
+BarotropicQGQL.set_zeta!(prob, zeros(g.X))
 
 function zetaMean(prob)
     sol = prob.state.sol

--- a/src/GeophysicalFlows.jl
+++ b/src/GeophysicalFlows.jl
@@ -2,6 +2,7 @@ module GeophysicalFlows
 
 include("twodturb.jl")
 include("barotropicqg.jl")
+include("barotropicqgql.jl")
 include("verticallycosineboussinesq.jl")
 include("verticallyfourierboussinesq.jl")
 

--- a/src/barotropicqgql.jl
+++ b/src/barotropicqgql.jl
@@ -261,7 +261,7 @@ function calcN_advection!(N, sol, t, s, v, p, g)
   @. v.u = v.u*v.Zeta # u*Ζ
   @. v.v = v.v*v.Zeta # v*Ζ
 
-  mul!(v.uh, g.rfftplan, v.U + v.u) # \hat{U*q}
+  mul!(v.uh, g.rfftplan, v.U + v.u) # \hat{U*ζ + u*Ζ}
   @. v.Nz = -im*g.kr*v.uh # -∂[U*ζ + u*Ζ]/∂x
   mul!(v.vh, g.rfftplan, v.v) # \hat{v*Z}
   @. v.Nz += - im*g.l*v.vh # -∂[v*Z]/∂y
@@ -366,15 +366,6 @@ function enstrophy(prob)
   0.5*parsevalsum2(v.uh, g)/(g.Lx*g.Ly)
 end
 
-"""
-Returns the energy of the domain-averaged U.
-"""
-energy00(prob) = real(0.5*prob.state.sol[1, 1].^2)
-
-"""
-Returns the enstrophy of the domain-averaged U.
-"""
-enstrophy00(prob) = real(prob.params.beta*prob.state.sol[1, 1])
 
 """
     dissipation(prob)

--- a/src/barotropicqgql.jl
+++ b/src/barotropicqgql.jl
@@ -1,0 +1,427 @@
+module BarotropicQGQL
+
+export
+  Problem,
+  set_zeta!,
+  updatevars!,
+
+  energy,
+  enstrophy,
+  energy00,
+  enstrophy00,
+  dissipation,
+  work,
+  drag
+
+using
+  FFTW,
+  Requires,
+  Reexport
+
+@reexport using FourierFlows
+
+using LinearAlgebra: mul!, ldiv!
+using FourierFlows: parsevalsum, parsevalsum2
+import FFTW: rfft
+
+abstract type BarotropicQGQLVars <: AbstractVars end
+abstract type BarotropicQGQLForcedVars <: BarotropicQGQLVars end
+
+const physicalvars = [:zeta, :psi, :u, :v, :uzeta, :vzeta, :U, :Zeta]
+const transformvars = [ Symbol(var, :h) for var in physicalvars ]
+const forcedvars = [:Fh]
+const stochforcedvars = [:prevsol]
+
+nothingfunction(args...) = nothing
+
+"""
+    Problem(; parameters...)
+
+Construct a BarotropicQGQL turbulence problem.
+"""
+function Problem(;
+    # Numerical parameters
+            nx = 256,
+            Lx = 2π,
+            ny = nx,
+            Ly = Lx,
+            dt = 0.01,
+    # Physical parameters
+            f0 = 1.0,
+          beta = 0.0,
+           eta = nothing,
+    # Drag and/or hyper-/hypo-viscosity
+            nu = 0.0,
+           nnu = 1,
+            mu = 0.0,
+   # Timestepper and eqn options
+       stepper = "RK4",
+         calcF = nothingfunction,
+    stochastic = false,
+             T = Float64)
+
+  # the grid
+  g  = BarotropicQGQL.TwoDGrid(nx, Lx, ny, Ly)
+
+  # topographic PV
+  if eta==nothing
+    eta = 0*g.X
+    etah = rfft(eta)
+  end
+
+  if typeof(eta)!=Array{Float64,2} #this is true if eta was passes in Problem as a function
+    pr = Params(g, f0, beta, eta, mu, nu, nnu, calcF)
+  else
+    pr = Params(f0, beta, eta, rfft(eta), mu, nu, nnu, calcF)
+  end
+  vs = calcF == nothingfunction ? Vars(g) : (stochastic ? StochasticForcedVars(g) : ForcedVars(g))
+  eq = BarotropicQGQL.Equation(pr, g)
+  ts = FourierFlows.autoconstructtimestepper(stepper, dt, eq.LC, g)
+  FourierFlows.Problem(g, vs, pr, eq, ts)
+end
+
+InitialValueProblem(; kwargs...) = Problem(; kwargs...)
+ForcedProblem(; kwargs...) = Problem(; kwargs...)
+
+
+# ----------
+# Parameters
+# ----------
+
+"""
+    Params(g::TwoDGrid, f0, beta, FU, eta, mu, nu, nnu)
+
+Returns the params for an unforced two-dimensional barotropic QG problem.
+"""
+struct Params{T} <: AbstractParams
+  f0::T                      # Constant planetary vorticity
+  beta::T                    # Planetary vorticity y-gradient
+  eta::Array{T,2}            # Topographic PV
+  etah::Array{Complex{T},2}  # FFT of Topographic PV
+  mu::T                      # Linear drag
+  nu::T                      # Viscosity coefficient
+  nnu::Int                   # Hyperviscous order (nnu=1 is plain old viscosity)
+  calcF!::Function           # Function that calculates the forcing on QGPV q
+end
+
+"""
+    Params(g::TwoDGrid, f0, beta, eta::Function, mu, nu, nnu)
+
+Constructor for Params that accepts a generating function for the topographic PV.
+"""
+function Params(g::TwoDGrid, f0, beta, eta::Function, mu, nu, nnu, calcF)
+  etagrid = eta(g.X, g.Y)
+  etah = rfft(etagrid)
+  Params(f0, beta, etagrid, etah, mu, nu, nnu, calcF)
+end
+
+
+# ---------
+# Equations
+# ---------
+
+"""
+    Equation(p, g)
+
+Returns the equation for two-dimensional barotropic QG problem with params p and grid g.
+"""
+function Equation(p::Params, g; T=typeof(g.Lx))
+  LC = @. -p.mu - p.nu*g.KKrsq^p.nnu + im*p.beta*g.kr*g.invKKrsq
+  LC[1, 1] = 0
+  FourierFlows.Equation{Complex{T},2}(LC, calcN!)
+end
+
+
+# ----
+# Vars
+# ----
+
+"""
+    Vars(g)
+
+Returns the vars for unforced two-dimensional barotropic QG problem with grid g.
+"""
+mutable struct Vars{T} <: BarotropicQGQLVars
+  u::Array{T,2}
+  v::Array{T,2}
+  U::Array{T,2}
+  uzeta::Array{T,2}
+  vzeta::Array{T,2}
+  zeta::Array{T,2}
+  Zeta::Array{T,2}
+  psi::Array{T,2}
+  Nz::Array{Complex{T},2}
+  NZ::Array{Complex{T},2}
+  uh::Array{Complex{T},2}
+  vh::Array{Complex{T},2}
+  Uh::Array{Complex{T},2}
+  zetah::Array{Complex{T},2}
+  Zetah::Array{Complex{T},2}
+  psih::Array{Complex{T},2}
+end
+
+function Vars(g; T=typeof(g.Lx))
+  @createarrays T (g.nx, g.ny) u v U uzeta vzeta zeta Zeta psi
+  @createarrays Complex{T} (g.nkr, g.nl) N NZ uh vh Uh zetah Zetah psih
+  Vars(u, v, U, uzeta, vzeta, zeta, Zeta, psi, N, NZ, uh, vh, Uh, zetah, Zetah, psih)
+end
+
+"""
+    ForcedVars(g)
+
+Returns the vars for forced two-dimensional barotropic QG problem with grid g.
+"""
+mutable struct ForcedVars{T} <: BarotropicQGQLForcedVars
+  u::Array{T,2}
+  v::Array{T,2}
+  U::Array{T,2}
+  uzeta::Array{T,2}
+  vzeta::Array{T,2}
+  zeta::Array{T,2}
+  Zeta::Array{T,2}
+  psi::Array{T,2}
+  Nz::Array{Complex{T},2}
+  NZ::Array{Complex{T},2}
+  uh::Array{Complex{T},2}
+  vh::Array{Complex{T},2}
+  Uh::Array{Complex{T},2}
+  zetah::Array{Complex{T},2}
+  Zetah::Array{Complex{T},2}
+  psih::Array{Complex{T},2}
+  Fh::Array{Complex{T},2}
+end
+
+function ForcedVars(g; T=typeof(g.Lx))
+  v = Vars(g; T=T)
+  Fh = zeros(Complex{T}, (g.nkr, g.nl))
+  ForcedVars(getfield.(Ref(v), fieldnames(typeof(v)))..., Fh)
+end
+
+
+mutable struct StochasticForcedVars{T} <: BarotropicQGQLForcedVars
+  u::Array{T,2}
+  v::Array{T,2}
+  U::Array{T,2}
+  uzeta::Array{T,2}
+  vzeta::Array{T,2}
+  zeta::Array{T,2}
+  Zeta::Array{T,2}
+  psi::Array{T,2}
+  Nz::Array{Complex{T},2}
+  NZ::Array{Complex{T},2}
+  uh::Array{Complex{T},2}
+  vh::Array{Complex{T},2}
+  Uh::Array{Complex{T},2}
+  zetah::Array{Complex{T},2}
+  Zetah::Array{Complex{T},2}
+  psih::Array{Complex{T},2}
+  Fh::Array{Complex{T},2}
+  prevsol::Array{Complex{T},2}
+end
+
+function StochasticForcedVars(g; T=typeof(g.Lx))
+  v = ForcedVars(g; T=T)
+  prevsol = zeros(Complex{T}, (g.nkr, g.nl))
+  StochasticForcedVars(getfield.(Ref(v), fieldnames(typeof(v)))..., prevsol)
+end
+
+
+# -------
+# Solvers
+# -------
+
+function calcN_advection!(N, sol, t, s, v, p, g)
+  # Note that U = sol[1, 1]. For all other elements ζ = sol
+  @. v.zetah = sol
+  @. v.zetah[g.Kr.==0] = 0
+  @. v.Zetah = sol
+  @. v.Zetah[abs.(g.Kr).>0] = 0
+
+  @. v.uh =  im * g.l  * g.invKKrsq * v.zetah
+  @. v.vh = -im * g.kr * g.invKKrsq * v.zetah
+  @. v.Uh =  im * g.l  * g.invKKrsq * v.Zetah
+
+  ldiv!(v.zeta, g.rfftplan, v.zetah)
+  ldiv!(v.u, g.rfftplan, v.uh)
+  ldiv!(v.v, g.rfftplan, v.vh)
+
+  ldiv!(v.Zeta, g.rfftplan, v.Zetah)
+  ldiv!(v.U, g.rfftplan, v.Uh)
+
+  @. v.uzeta = v.u*v.zeta # u*ζ
+  @. v.vzeta = v.v*v.zeta # v*ζ
+
+  mul!(v.uh, g.rfftplan, v.uzeta) # \hat{u*q}
+  @. v.NZ = -im*g.kr*v.uh # -∂[u*q]/∂x
+  mul!(v.vh, g.rfftplan, v.vzeta) # \hat{v*q}
+  @. v.NZ += - im*g.l*v.vh # -∂[v*q]/∂y
+  @. v.NZ[abs.(g.Kr).>0] = 0
+
+  @. v.U = v.U*v.zeta # U*ζ
+  @. v.u = v.u*v.Zeta # u*Ζ
+  @. v.v = v.v*v.Zeta # v*Ζ
+
+  mul!(v.uh, g.rfftplan, v.U + v.u) # \hat{U*q}
+  @. v.Nz = -im*g.kr*v.uh # -∂[U*ζ + u*Ζ]/∂x
+  mul!(v.vh, g.rfftplan, v.v) # \hat{v*Z}
+  @. v.Nz += - im*g.l*v.vh # -∂[v*Z]/∂y
+  @. v.Nz[abs.(g.Kr).==0] = 0
+
+  @. N = v.NZ + v.Nz
+end
+
+function calcN!(N, sol, t, s, v, p, g)
+  calcN_advection!(N, sol, t, s, v, p, g)
+  addforcing!(N, t, s, v, p, g)
+  nothing
+end
+
+addforcing!(N, t, s, v::Vars, p, g) = nothing
+
+function addforcing!(N, t, s, v::ForcedVars, p, g)
+  p.calcF!(v.Fh, t, s, v, p, g)
+  @. N += v.Fh
+  nothing
+end
+
+function addforcing!(N, t, s, v::StochasticForcedVars, p, g)
+  if t == s.t # not a substep
+    @. v.prevsol = s.sol # sol at previous time-step is needed to compute budgets for stochastic forcing
+    p.calcF!(v.Fh, t, s, v, p, g)
+  end
+  @. N += v.Fh
+  nothing
+end
+
+
+# ----------------
+# Helper functions
+# ----------------
+
+"""
+    updatevars!(v, s, g)
+
+Update the vars in v on the grid g with the solution in s.sol.
+"""
+function updatevars!(s, v, p, g)
+  s.sol[1, 1] = 0
+  @. v.zetah = s.sol
+  @. v.zetah[g.Kr.==0] = 0
+  @. v.Zetah = s.sol
+  @. v.Zetah[abs.(g.Kr).>0] = 0
+
+  @. v.psih = -v.zetah * g.invKKrsq
+  @. v.uh = -im * g.l  * v.psih
+  @. v.vh =  im * g.kr * v.psih
+  @. v.Uh =  im * g.l  * v.Zetah * g.invKKrsq
+
+  ldiv!(v.zeta, g.rfftplan, deepcopy(v.zetah))
+  ldiv!(v.Zeta, g.rfftplan, deepcopy(v.Zetah))
+  ldiv!(v.psi, g.rfftplan, v.psih)
+  ldiv!(v.u, g.rfftplan, deepcopy(v.uh))
+  ldiv!(v.v, g.rfftplan, deepcopy(v.vh))
+  ldiv!(v.U, g.rfftplan, deepcopy(v.Uh))
+
+  nothing
+end
+
+updatevars!(prob) = updatevars!(prob.state, prob.vars, prob.params, prob.grid)
+
+"""
+    set_zeta!(prob, zeta)
+    set_zeta!(s, v, g, zeta)
+
+Set the solution s.sol as the transform of zeta and update variables v
+on the grid g.
+"""
+function set_zeta!(s, v, p, g, zeta)
+  mul!(v.zetah, g.rfftplan, zeta)
+  v.zetah[1, 1] = 0.0
+  @. s.sol = v.zetah
+
+  updatevars!(s, v, p, g)
+  nothing
+end
+
+set_zeta!(prob::AbstractProblem, zeta) = set_zeta!(prob.state, prob.vars, prob.params, prob.grid, zeta)
+
+
+"""
+Calculate the domain-averaged kinetic energy.
+"""
+function energy(prob::AbstractProblem)
+  s, g = prob.state, prob.grid
+  0.5*(parsevalsum2(g.Kr.*g.invKKrsq.*s.sol, g)
+        + parsevalsum2(g.Lr.*g.invKKrsq.*s.sol, g))/(g.Lx*g.Ly)
+end
+
+
+"""
+Returns the domain-averaged enstrophy.
+"""
+function enstrophy(prob)
+  s, v, g = prob.state, prob.vars, prob.grid
+  @. v.uh = s.sol
+  v.uh[1, 1] = 0
+  0.5*parsevalsum2(v.uh, g)/(g.Lx*g.Ly)
+end
+
+"""
+Returns the energy of the domain-averaged U.
+"""
+energy00(prob) = real(0.5*prob.state.sol[1, 1].^2)
+
+"""
+Returns the enstrophy of the domain-averaged U.
+"""
+enstrophy00(prob) = real(prob.params.beta*prob.state.sol[1, 1])
+
+"""
+    dissipation(prob)
+    dissipation(s, v, p, g)
+
+Returns the domain-averaged dissipation rate. nnu must be >= 1.
+"""
+@inline function dissipation(s, v, p, g)
+  @. v.uh = g.KKrsq^(p.nnu-1) * abs2(s.sol)
+  v.uh[1, 1] = 0
+  p.nu/(g.Lx*g.Ly)*parsevalsum(v.uh, g)
+end
+
+@inline dissipation(prob::AbstractProblem) = dissipation(prob.state, prob.vars, prob.params, prob.grid)
+
+"""
+    work(prob)
+    work(s, v, p, g)
+
+Returns the domain-averaged rate of work of energy by the forcing Fh.
+"""
+@inline function work(s, v::ForcedVars, g)
+  @. v.uh = g.invKKrsq * s.sol * conj(v.Fh)
+  1/(g.Lx*g.Ly)*parsevalsum(v.uh, g)
+end
+
+@inline function work(s, v::StochasticForcedVars, g)
+  @. v.uh = g.invKKrsq * (v.prevsol + s.sol)/2.0 * conj(v.Fh) # Stratonovich
+  # @. v.uh = g.invKKrsq * v.prevsol * conj(v.Fh)             # Ito
+  1/(g.Lx*g.Ly)*parsevalsum(v.uh, g)
+end
+
+@inline work(prob::AbstractProblem) = work(prob.state, prob.vars, prob.grid)
+
+"""
+    drag(prob)
+    drag(s, v, p, g)
+
+Returns the extraction of domain-averaged energy by drag mu.
+"""
+@inline function drag(s, v, p, g)
+  @. v.uh = g.KKrsq^(-1) * abs2(s.sol)
+  @. v.uh[1, 1] = 0
+  p.mu/(g.Lx*g.Ly)*parsevalsum(v.uh, g)
+end
+
+@inline drag(prob::AbstractProblem) = drag(prob.state, prob.vars, prob.params, prob.grid)
+
+
+end # module

--- a/src/barotropicqgql.jl
+++ b/src/barotropicqgql.jl
@@ -417,7 +417,7 @@ Returns the extraction of domain-averaged energy by drag mu.
 """
 @inline function drag(s, v, p, g)
   @. v.uh = g.KKrsq^(-1) * abs2(s.sol)
-  @. v.uh[1, 1] = 0
+  v.uh[1, 1] = 0
   p.mu/(g.Lx*g.Ly)*parsevalsum(v.uh, g)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 #!/usr/bin/env julia
 
-using 
+using
   FourierFlows,
   Test,
   Statistics,
@@ -10,6 +10,7 @@ using
 import # use 'import' rather than 'using' for submodules to keep namespace clean
   GeophysicalFlows.TwoDTurb,
   GeophysicalFlows.BarotropicQG,
+  GeophysicalFlows.BarotropicQGQL,
   GeophysicalFlows.VerticallyCosineBoussinesq,
   GeophysicalFlows.VerticallyFourierBoussinesq
 
@@ -24,7 +25,7 @@ e1_fourier(u, v, p, m, N) = @. abs2(u) + abs2(v) + m^2*abs2(p)/N^2
 e1_fourier(prob) = e1_fourier(prob.vars.u, prob.vars.v, prob.vars.p, prob.params.m, prob.params.N)
 
 "Returns the x,y centroid of a cosine mode 1 internal wave in the Boussinesq equations."
-wavecentroid_fourier(prob) = (FourierFlows.xmoment(e1_fourier(prob), prob.grid), 
+wavecentroid_fourier(prob) = (FourierFlows.xmoment(e1_fourier(prob), prob.grid),
                              FourierFlows.ymoment(e1_fourier(prob), prob.grid))
 
 "Returns the energy in vertically cosine mode 1 in the Boussinesq equations."
@@ -32,7 +33,7 @@ e1_cosine(u, v, p, m, N) = @. ( u^2 + v^2 + m^2*p^2/N^2 )/2
 e1_cosine(prob) = e1_cosine(prob.vars.u, prob.vars.v, prob.vars.p, prob.params.m, prob.params.N)
 
 "Returns the x,y centroid of a cosine mode 1 internal wave in the Boussinesq equations."
-wavecentroid_cosine(prob) = (FourierFlows.xmoment(e1_cosine(prob), prob.grid), 
+wavecentroid_cosine(prob) = (FourierFlows.xmoment(e1_cosine(prob), prob.grid),
                              FourierFlows.ymoment(e1_cosine(prob), prob.grid))
 
 # Run tests
@@ -44,6 +45,10 @@ end
 
 @testset "BarotropicQG" begin
   include("test_barotropicqg.jl")
+end
+
+@testset "BarotropicQGQL" begin
+  include("test_barotropicqgql.jl")
 end
 
 @testset "Vertically Cosine Boussinesq" begin

--- a/test/test_barotropicqgql.jl
+++ b/test/test_barotropicqgql.jl
@@ -1,0 +1,291 @@
+"""
+    test_bqgql_rossbywave(; kwargs...)
+
+Evolvesa a Rossby wave and compares with the analytic solution.
+"""
+function test_bqgql_rossbywave(stepper, dt, nsteps)
+    nx = 64
+  beta = 2.0
+    Lx = 2π
+    mu = 0.0
+    nu = 0.0
+
+  # the following if statement is called so that all the cases of
+  # Problem() fuction are tested
+  if stepper=="ForwardEuler"
+    eta = zeros(nx, nx)
+  else
+    eta(x, y) = 0*x
+  end
+
+  prob = BarotropicQGQL.InitialValueProblem(nx=nx, Lx=Lx, eta=eta, beta=beta, mu=mu, nu=nu, stepper=stepper, dt=dt)
+  s, v, p, g = prob.state, prob.vars, prob.params, prob.grid
+
+  # the Rossby wave initial condition
+   ampl = 1e-2
+  kwave = 3.0*2π/g.Lx
+  lwave = 2.0*2π/g.Ly
+      ω = -p.beta*kwave/(kwave^2.0 + lwave^2.0)
+     ζ0 = ampl*cos.(kwave*g.X).*cos.(lwave*g.Y)
+    ζ0h = rfft(ζ0)
+
+  BarotropicQGQL.set_zeta!(prob, ζ0)
+
+  stepforward!(prob, nsteps)
+  dealias!(s.sol, g)
+  BarotropicQGQL.updatevars!(prob)
+
+  ζ_theory = ampl*cos.(kwave*(g.X .- ω/kwave*s.t)) .* cos.(lwave*g.Y)
+
+  isapprox(ζ_theory, v.zeta, rtol=g.nx*g.ny*nsteps*1e-12)
+end
+
+"""
+    test_stochasticforcingbudgets(; kwargs...)
+
+Tests if the energy budgets are closed for BarotropicQG with stochastic forcing.
+"""
+function test_bqgql_stochasticforcingbudgets(; n=256, dt=0.01, L=2π, nu=1e-7, nnu=2, mu=1e-1, message=false)
+  n, L  = 256, 2π
+  nu, nnu = 1e-7, 2
+  mu = 1e-1
+  dt, tf = 0.005, 0.1/mu
+  nt = round(Int, tf/dt)
+  ns = 1
+
+  # Forcing
+  kf, dkf = 12.0, 2.0
+  σ = 0.1
+  gr  = TwoDGrid(n, L)
+
+  force2k = zero(gr.Kr)
+  @. force2k = exp.(-(sqrt(gr.KKrsq)-kf)^2/(2*dkf^2))
+  @. force2k[gr.KKrsq .< 2.0^2 ] = 0
+  @. force2k[gr.KKrsq .> 20.0^2 ] = 0
+  @. force2k[gr.Kr .< 2π/L] = 0
+  σ0 = parsevalsum(force2k.*gr.invKKrsq/2.0, gr)/(gr.Lx*gr.Ly)
+  force2k .= σ/σ0 * force2k
+
+  Random.seed!(1234)
+
+  function calcF!(F, t, s, v, p, g)
+    eta = exp.(2π*im*rand(Float64, size(s.sol)))/sqrt(s.dt)
+    eta[1, 1] = 0
+    @. F = eta .* sqrt(force2k)
+    nothing
+  end
+
+  prob = BarotropicQGQL.ForcedProblem(nx=n, Lx=L, nu=nu, nnu=nnu, mu=mu, dt=dt,
+   stepper="RK4", calcF=calcF!, stochastic=true)
+
+  s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts
+
+  BarotropicQGQL.set_zeta!(prob, 0*g.X)
+  E = Diagnostic(BarotropicQGQL.energy,      prob, nsteps=nt)
+  D = Diagnostic(BarotropicQGQL.dissipation, prob, nsteps=nt)
+  R = Diagnostic(BarotropicQGQL.drag,        prob, nsteps=nt)
+  W = Diagnostic(BarotropicQGQL.work,        prob, nsteps=nt)
+  diags = [E, D, W, R]
+
+  # Step forward
+
+  stepforward!(prob, diags, round(Int, nt))
+
+  BarotropicQGQL.updatevars!(prob)
+
+  cfl = prob.ts.dt*maximum([maximum(v.v)/g.dx, maximum(v.u)/g.dy])
+
+  E, D, W, R = diags
+
+  t = round(mu*prob.state.t, digits=2)
+
+  i₀ = 1
+  dEdt = (E[(i₀+1):E.count] - E[i₀:E.count-1])/prob.ts.dt
+  ii = (i₀):E.count-1
+  ii2 = (i₀+1):E.count
+
+  # dEdt = W - D - R?
+  # If the Ito interpretation was used for the work
+  # then we need to add the drift term
+  # total = W[ii2]+σ - D[ii] - R[ii]      # Ito
+  total = W[ii2] - D[ii] - R[ii]        # Stratonovich
+
+  residual = dEdt - total
+
+  if message
+    println("step: %04d, t: %.1f, cfl: %.3f, time: %.2f s\n", prob.step, prob.t, cfl, tc)
+  end
+  # println(mean(abs.(residual)))
+  isapprox(mean(abs.(residual)), 0, atol=1e-4)
+end
+
+"""
+    test_stochasticforcingbudgets(; kwargs...)
+
+Tests if the energy budgets are closed for BarotropicQG with stochastic forcing.
+"""
+function test_bqgql_deterministicforcingbudgets(; n=256, dt=0.01, L=2π, nu=1e-7, nnu=2, mu=1e-1, message=false)
+  n, L  = 256, 2π
+  nu, nnu = 1e-7, 2
+  mu = 1e-1
+  dt, tf = 0.005, 0.1/mu
+  nt = round(Int, tf/dt)
+  ns = 1
+
+
+  # Forcing = 0.01cos(4x)cos(5y)cos(2t)
+  gr  = TwoDGrid(n, L)
+  f = @. 0.01*cos(4*gr.kr[2]*gr.X)*cos(5*gr.l[2]*gr.Y)
+  fh = rfft(f)
+  function calcF!(Fh, t, s, v, p, g)
+    @. Fh = fh*cos(2*t)
+    nothing
+  end
+
+  prob = BarotropicQGQL.ForcedProblem(nx=n, Lx=L, nu=nu, nnu=nnu, mu=mu, dt=dt,
+   stepper="RK4", calcF=calcF!, stochastic=false)
+
+  s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts;
+
+  BarotropicQGQL.set_zeta!(prob, 0*g.X)
+  E = Diagnostic(BarotropicQGQL.energy,      prob, nsteps=nt)
+  D = Diagnostic(BarotropicQGQL.dissipation, prob, nsteps=nt)
+  R = Diagnostic(BarotropicQGQL.drag,        prob, nsteps=nt)
+  W = Diagnostic(BarotropicQGQL.work,        prob, nsteps=nt)
+  diags = [E, D, W, R]
+
+  # Step forward
+
+  stepforward!(prob, diags, round(Int, nt))
+
+  BarotropicQGQL.updatevars!(prob)
+
+  cfl = prob.ts.dt*maximum([maximum(v.v)/g.dx, maximum(v.u)/g.dy])
+
+  E, D, W, R = diags
+
+  t = round(mu*prob.state.t, digits=2)
+
+  i₀ = 1
+  dEdt = (E[(i₀+1):E.count] - E[i₀:E.count-1])/prob.ts.dt
+  ii = (i₀):E.count-1
+  ii2 = (i₀+1):E.count
+
+  # dEdt = W - D - R?
+  total = W[ii2] - D[ii] - R[ii]
+
+  residual = dEdt - total
+
+  if message
+    println("step: %04d, t: %.1f, cfl: %.3f, time: %.2f s\n", prob.step, prob.t, cfl, tc)
+  end
+  # println(mean(abs.(residual)))
+  isapprox(mean(abs.(residual)), 0, atol=1e-8)
+end
+
+"""
+    test_bqgql_nonlinearadvection(dt, stepper; kwargs...)
+
+Tests the advection term in the twodturb module by timestepping a
+test problem with timestep dt and timestepper identified by the string stepper.
+The test problem is derived by picking a solution ζf (with associated
+streamfunction ψf) for which the advection term J(ψf, ζf) is non-zero. Next, a
+forcing Ff is derived according to Ff = ∂ζf/∂t + J(ψf, ζf) - nuΔζf. One solution
+to the vorticity equation forced by this Ff is then ζf. (This solution may not
+be realized, at least at long times, if it is unstable.)
+"""
+function test_bqgql_advection(dt, stepper; n=128, L=2π, nu=1e-2, nnu=1, mu=0.0, message=false)
+  n, L  = 128, 2π
+  nu, nnu = 1e-2, 1
+  mu = 0.0
+  tf = 1.0
+  nt = round(Int, tf/dt)
+
+  gr  = TwoDGrid(n, L)
+  x, y = gr.X, gr.Y
+
+  psif =    cos.(3y) +  sin.(2x).*cos.(2y) +  2sin.(x).*cos.(3y)
+    qf = - 9cos.(3y) - 8sin.(2x).*cos.(2y) - 20sin.(x).*cos.(3y)
+
+  Ff = nu*( 81cos.(3y) .+ 200cos.(3y).*sin.(x) .+ 64cos.(2y).*sin.(2x) ) -
+    3sin.(3y).*(-16cos.(2x).*cos.(2y) .- 20cos.(x).*cos.(3y)) .-
+ 27sin.(3y).*(2cos.(2x).*cos.(2y) .+ 2cos.(x).*cos.(3y)) .+ 0*(-8cos.(x).*cos.(3y).*sin.(2x).*sin(2y) +
+ 24*cos.(2x).*cos.(2y).*sin.(x).*sin.(3y))
+
+
+  Ffh = -rfft(Ff)
+
+  # Forcing
+  function calcF!(Fh, t, s, v, p, g)
+    Fh .= Ffh
+    nothing
+  end
+
+  prob = BarotropicQGQL.ForcedProblem(nx=n, Lx=L, nu=nu, nnu=nnu, mu=mu, dt=dt, stepper=stepper, calcF=calcF!)
+  s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts
+  BarotropicQGQL.set_zeta!(prob, qf)
+
+  # Step forward
+  stepforward!(prob, round(Int, nt))
+  BarotropicQGQL.updatevars!(prob)
+  isapprox(v.zeta+v.Zeta, qf, rtol=1e-13)
+end
+
+function test_bqgql_energyenstrophy()
+  nx, Lx  = 64, 2π
+  ny, Ly  = 64, 3π
+  g  = TwoDGrid(nx, Lx, ny, Ly)
+  k0 = g.k[2] # fundamental wavenumber
+  l0 = g.l[2] # fundamental wavenumber
+  x, y = g.X, g.Y
+
+    eta = @. cos(10*k0*x)*cos(10*l0*y)
+   psi0 = @. sin(2*k0*x)*cos(2*l0*y) + 2sin(k0*x)*cos(3*l0*y)
+  zeta0 = @. -((2*k0)^2+(2*l0)^2)*sin(2*k0*x)*cos(2*l0*y) - (k0^2+(3*l0)^2)*2sin(k0*x)*cos(3*l0*y)
+
+  prob = BarotropicQGQL.InitialValueProblem(nx=nx, Lx=Lx, ny=ny, Ly=Ly, eta = eta, stepper="ForwardEuler")
+  s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts
+  BarotropicQGQL.set_zeta!(prob, zeta0)
+  BarotropicQGQL.updatevars!(prob)
+
+  energyzeta0 = BarotropicQGQL.energy(prob)
+  enstrophyzeta0 = BarotropicQGQL.enstrophy(prob)
+
+  isapprox(energyzeta0, 29.0/9, rtol=1e-13) && isapprox(enstrophyzeta0, 2701.0/162, rtol=1e-13)
+end
+
+# -----------------------------------------------------------------------------
+# Running the tests
+
+
+dt, nsteps, stepper  = 1e-2, 20, "ETDRK4"
+@test test_bqgql_rossbywave("ETDRK4", dt, nsteps)
+
+dt, nsteps  = 1e-2, 20;
+@test test_bqgql_rossbywave("FilteredETDRK4", dt, nsteps)
+
+dt, nsteps  = 1e-2, 20
+@test test_bqgql_rossbywave("RK4", dt, nsteps)
+
+dt, nsteps  = 1e-2, 20
+@test test_bqgql_rossbywave("FilteredRK4", dt, nsteps)
+
+dt, nsteps  = 1e-3, 200
+@test test_bqgql_rossbywave("AB3", dt, nsteps)
+
+dt, nsteps  = 1e-3, 200
+@test test_bqgql_rossbywave("FilteredAB3", dt, nsteps)
+
+dt, nsteps  = 1e-4, 2000
+@test test_bqgql_rossbywave("ForwardEuler", dt, nsteps)
+
+dt, nsteps  = 1e-4, 2000
+@test test_bqgql_rossbywave("FilteredForwardEuler", dt, nsteps)
+
+@test test_bqgql_deterministicforcingbudgets()
+
+@test test_bqgql_stochasticforcingbudgets()
+
+@test test_bqgql_advection(0.0005, "ForwardEuler")
+
+@test test_bqgql_energyenstrophy()


### PR DESCRIPTION
This is the quasilinear version of the `BarotropicQG` module.
It only includes implemention of the plain-old barotropic vorticity equation. It does not include any large-scale domain-average zonal flow `U(t)`