### PR TITLE
Changes notation q, qh --> zeta, zetah in TwoDTurb

### DIFF
--- a/docs/src/modules/twodturb.md
+++ b/docs/src/modules/twodturb.md
@@ -9,11 +9,11 @@
 This module solves two-dimensional incompressible turbulence. The flow is given
 through a streamfunction $\psi$ as $(u,\upsilon) = (-\partial_y\psi, \partial_x\psi)$.
 The dynamical variable used here is the component of the vorticity of the flow
-normal to the plane of motion, $q=\partial_x \upsilon- \partial_y u = \nabla^2\psi$.
+normal to the plane of motion, $\zeta=\partial_x \upsilon- \partial_y u = \nabla^2\psi$.
 The equation solved by the module is:
 
-$$\partial_t q + \J(\psi, q) = \underbrace{-\left[\mu(-1)^{n_\mu} \nabla^{2n_\mu}
-+\nu(-1)^{n_\nu} \nabla^{2n_\nu}\right] q}_{\textrm{dissipation}} + f\ .$$
+$$\partial_t \zeta + \J(\psi, \zeta) = \underbrace{-\left[\mu(-1)^{n_\mu} \nabla^{2n_\mu}
++\nu(-1)^{n_\nu} \nabla^{2n_\nu}\right] \zeta}_{\textrm{dissipation}} + f\ .$$
 
 where $\J(a, b) = (\partial_x a)(\partial_y b)-(\partial_y a)(\partial_x b)$. On
 the right hand side, $f(x,y,t)$ is forcing, $\mu$ is hypoviscosity, and $\nu$ is
@@ -24,8 +24,8 @@ viscosity corresponds to $n_{\nu}=1$.
 
 The equation is time-stepped forward in Fourier space:
 
-$$\partial_t \widehat{q} = - \widehat{J(\psi, q)} -\left(\mu k^{2n_\mu}
-+\nu k^{2n_\nu}\right) \widehat{q}  + \widehat{f}\ .$$
+$$\partial_t \widehat{\zeta} = - \widehat{J(\psi, \zeta)} -\left(\mu k^{2n_\mu}
++\nu k^{2n_\nu}\right) \widehat{\zeta}  + \widehat{f}\ .$$
 
 In doing so the Jacobian is computed in the conservative form: $\J(a,b) =
 \partial_y [ (\partial_x a) b] -\partial_x[ (\partial_y a) b]$.
@@ -33,8 +33,8 @@ In doing so the Jacobian is computed in the conservative form: $\J(a,b) =
 Thus:
 
 $$\mathcal{L} = -\mu k^{-2n_\mu} - \nu k^{2n_\nu}\ ,$$
-$$\mathcal{N}(\widehat{q}) = - \mathrm{i}k_x \mathrm{FFT}(u q)-
-	\mathrm{i}k_y \mathrm{FFT}(\upsilon q) + \widehat{f}\ .$$
+$$\mathcal{N}(\widehat{\zeta}) = - \mathrm{i}k_x \mathrm{FFT}(u \zeta)-
+	\mathrm{i}k_y \mathrm{FFT}(\upsilon \zeta) + \widehat{f}\ .$$
 
 
 ### AbstractTypes and Functions
@@ -54,13 +54,13 @@ For the forced case ($f\ne 0$) parameters AbstractType is build with `ForcedPara
 **Vars**
 
 For the unforced case ($f=0$) variables AbstractType is build with `Vars` and it includes:
-- `q`: Array of Floats; relative vorticity.
-- `U`: Array of Floats; $x$-velocity, $u$.
-- `V`: Array of Floats; $y$-velocity, $v$.
-- `sol`: Array of Complex; the solution, $\widehat{q}$.
-- `qh`: Array of Complex; the Fourier transform $\widehat{q}$.
-- `Uh`: Array of Complex; the Fourier transform $\widehat{u}$.
-- `Vh`: Array of Complex; the Fourier transform $\widehat{v}$.
+- `zeta`: Array of Floats; relative vorticity.
+- `u`: Array of Floats; $x$-velocity, $u$.
+- `v`: Array of Floats; $y$-velocity, $\upsilon$.
+- `sol`: Array of Complex; the solution, $\widehat{\zeta}$.
+- `zetah`: Array of Complex; the Fourier transform $\widehat{\zeta}$.
+- `uh`: Array of Complex; the Fourier transform $\widehat{u}$.
+- `vh`: Array of Complex; the Fourier transform $\widehat{\upsilon}$.
 
 For the forced case ($f\ne 0$) variables AbstractType is build with `ForcedVars`. It includes all variables in `Vars` and additionally:
 - `Fh`: Array of Complex; the Fourier transform $\widehat{f}$.
@@ -70,51 +70,21 @@ For the forced case ($f\ne 0$) variables AbstractType is build with `ForcedVars`
 
 **`calcN!` function**
 
-The nonlinear term $\mathcal{N}(\widehat{q})$ is computed via functions:
+The nonlinear term $\mathcal{N}(\widehat{\zeta})$ is computed via functions:
 
-- `calcN_advection!`: computes $- \widehat{J(\psi, q)}$ and stores it in array `N`.
+- `calcN_advection!`: computes $- \widehat{J(\psi, \zeta)}$ and stores it in array `N`.
 
-```julia
-function calcN_advection!(N, sol, t, s, v, p, g)
-  @. v.Uh =  im * g.l  * g.invKrsq * sol
-  @. v.Vh = -im * g.kr * g.invKrsq * sol
-  @. v.qh = sol
+- `calcN_forced!`: computes $- \widehat{J(\psi, \zeta)}$ via `calcN_advection!` and then adds to it the forcing $\widehat{f}$ computed via `calcF!` function. Also saves the solution $\widehat{\zeta}$ of the previous time-step in array `prevsol`.
 
-  A_mul_B!(v.U, g.irfftplan, v.Uh)
-  A_mul_B!s(v.V, g.irfftplan, v.Vh)
-  A_mul_B!(v.q, g.irfftplan, v.qh)
-
-  @. v.U *= v.q # U*q
-  @. v.V *= v.q # V*q
-
-  A_mul_B!(v.Uh, g.rfftplan, v.U) # \hat{U*q}
-  A_mul_B!(v.Vh, g.rfftplan, v.V) # \hat{U*q}
-
-  @. N = -im*g.kr*v.Uh - im*g.l*v.Vh
-  nothing
-end
-```
-
-- `calcN_forced!`: computes $- \widehat{J(\psi, q)}$ via `calcN_advection!` and then adds to it the forcing $\widehat{f}$ computed via `calcF!` function. Also saves the solution $\widehat{q}$ of the previous time-step in array `prevsol`.
-
-```julia
-function calcN_forced!(N, sol, t, s, v, p, g)
-  calcN_advection!(N, sol, t, s, v, p, g)
-  if t == s.t # not a substep
-    v.prevsol .= s.sol # used to compute budgets when forcing is stochastic
-    p.calcF!(v.Fh, sol, t, s, v, p, g)
-  end
-  @. N += v.Fh
-  nothing
-end
-```
-- `updatevars!`: uses `sol` to compute $q$, $u$, $v$, $\widehat{u}$, and $\widehat{v}$ and stores them into corresponding arrays of `Vars`/`ForcedVars`.
+- `updatevars!`: uses `sol` to compute $\zeta$, $u$, $\upsilon$, $\widehat{u}$, and $\widehat{\upsilon}$ and stores them into corresponding arrays of `Vars`/`ForcedVars`.
 
 
 ## Examples
 
-- `examples/twodturb/McWilliams.jl`: A script that simulates decaying two-dimensional turbulence reproducing the results of the paper by
+- `examples/twodturb_mcwilliams1984.jl`: A script that simulates decaying two-dimensional turbulence reproducing the results of the paper by
 
   > McWilliams, J. C. (1984). The emergence of isolated coherent vortices in turbulent flow. *J. Fluid Mech.*, **146**, 21-43.
 
-- `examples/twodturb/IsotropicRingForcing.jl`: A script that simulates stochastically forced two-dimensional turbulence. The forcing is temporally delta-corraleted and its spatial structure is isotropic with power in a narrow annulus of total radius $k_f$ in wavenumber space.
+- `examples/twodturb_randomdecay.jl`: A script that simulates decaying two-dimensional turbulence starting from random initial conditions.
+
+- `examples/twodturb_stochasticforcing.jl`: A script that simulates forced-dissipative two-dimensional turbulence with isotropic temporally delta-correlated stochastic forcing.

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -45,7 +45,7 @@ sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 filepath = "."
 plotpath = "./plots_2layer"
 plotname = "snapshots"
-filename = joinpath(filepath, "2layer.jl.jld2")
+filename = joinpath(filepath, "2layer.jld2")
 
 # File management
 if isfile(filename); rm(filename); end

--- a/examples/twodturb_mcwilliams1984.jl
+++ b/examples/twodturb_mcwilliams1984.jl
@@ -35,8 +35,8 @@ x, y = gridpoints(gr)
 # that reproduces the results of the paper by McWilliams (1984)
 seed!(1234)
 k0, E0 = 6, 0.5
-qi = peakedisotropicspectrum(gr, k0, E0, mask=filter)
-TwoDTurb.set_q!(prob, qi)
+zetai = peakedisotropicspectrum(gr, k0, E0, mask=filter)
+TwoDTurb.set_zeta!(prob, zetai)
 
 # Create Diagnostic -- energy and enstrophy are functions imported at the top.
 E = Diagnostic(energy, prob; nsteps=nsteps)
@@ -45,7 +45,7 @@ diags = [E, Z] # A list of Diagnostics types passed to "stepforward!" will
 # be updated every timestep.
 
 # Create Output
-get_sol(prob) = prob.vars.sol # extracts the Fourier-transformed solution
+get_sol(prob) = prob.sol # extracts the Fourier-transformed solution
 get_u(prob) = irfft(im*gr.l.*gr.invKrsq.*sol, gr.nx)
 out = Output(prob, filename, (:sol, get_sol), (:u, get_u))
 
@@ -54,7 +54,7 @@ function plot_output(prob, fig, axs; drawcolorbar=false)
   # Plot the vorticity field and the evolution of energy and enstrophy.
   TwoDTurb.updatevars!(prob)
   sca(axs[1])
-  pcolormesh(x, y, vs.q)
+  pcolormesh(x, y, vs.zeta)
   clim(-40, 40)
   axis("off")
   axis("square")

--- a/examples/twodturb_randomdecay.jl
+++ b/examples/twodturb_randomdecay.jl
@@ -18,7 +18,7 @@ ntot = 10nint   # Number of total timesteps
 
 # Define problem
 prob = TwoDTurb.Problem(nx=nx, Lx=Lx, nu=nu, nnu=nnu, dt=dt, stepper="FilteredRK4")
-TwoDTurb.set_q!(prob, rand(nx, nx))
+TwoDTurb.set_zeta!(prob, rand(nx, nx))
 
 cl, vs, gr = prob.clock, prob.vars, prob.grid
 x, y = gridpoints(gr)
@@ -27,7 +27,7 @@ x, y = gridpoints(gr)
 function makeplot!(ax, prob)
   sca(ax)
   cla()
-  pcolormesh(x, y, vs.q)
+  pcolormesh(x, y, vs.zeta)
   title("Vorticity")
   xlabel(L"x")
   ylabel(L"y")
@@ -56,7 +56,7 @@ kr, Ehr = FourierFlows.radialspectrum(Eh, gr, refinement=1)
 fig2, axs = subplots(ncols=2, figsize=(8, 4))
 
 sca(axs[1])
-pcolormesh(x, y, vs.q)
+pcolormesh(x, y, vs.zeta)
 xlabel(L"x")
 ylabel(L"y")
 title("Vorticity")

--- a/examples/twodturb_stochasticforcing.jl
+++ b/examples/twodturb_stochasticforcing.jl
@@ -43,7 +43,7 @@ prob = TwoDTurb.Problem(nx=n, Lx=L, nu=nu, nnu=nnu, mu=mu, nmu=nmu, dt=dt, stepp
 
 sol, cl, v, p, g = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 
-TwoDTurb.set_q!(prob, 0*x)
+TwoDTurb.set_zeta!(prob, 0*x)
 E = Diagnostic(energy,      prob, nsteps=nt)
 D = Diagnostic(dissipation, prob, nsteps=nt)
 R = Diagnostic(drag,        prob, nsteps=nt)
@@ -57,7 +57,7 @@ function makeplot(prob, diags)
 
   t = round(mu*cl.t, digits=2)
   sca(axs[1]); cla()
-  pcolormesh(x, y, v.q)
+  pcolormesh(x, y, v.zeta)
   xlabel(L"$x$")
   ylabel(L"$y$")
   title("\$\\nabla^2\\psi(x,y,\\mu t= $t )\$")


### PR DESCRIPTION
This addresses #17.
With new notation relative vorticity has the same notation in `TwoDTurb`, `BarotropicQG`, and `BarotropicQGQL`.