### PR TITLE
Plots replace PyPlot in TwoDNavierStokes examples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "44ee3b1c-bc02-53fa-8355-8e347616e15e"
 license = "MIT"
 authors = ["Navid C. Constantinou <navidcy@gmail.com>", "Gregory L. Wagner <wagner.greg@gmail.com>"]
 version = "0.4.1"
-versions = ["0.1.0", "0.2.0", "0.3.0", "0.3.3",  "0.3.4", "0.4.0", "0.4.1"]
+versions = ["0.1.0", "0.2.0", "0.3.0", "0.3.3", "0.3.4", "0.4.0", "0.4.1"]
 
 [deps]
 CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,9 +4,11 @@ FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FourierFlows = "2aec4490-903f-5c70-9b11-9bed06a700e1"
 GeophysicalFlows = "44ee3b1c-bc02-53fa-8355-8e347616e15e"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 
 [compat]
-FourierFlows = "≥ 0.4.1"
+FourierFlows = "≥ 0.4.4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,9 +3,15 @@ push!(LOAD_PATH, "..")
 using
   Documenter,
   Literate,
+  Plots,  # to not capture precompilation output
   PyPlot, # to not capture precompilation output
   GeophysicalFlows,
   GeophysicalFlows.TwoDNavierStokes
+
+# Gotta set this environment variable when using the GR run-time on Travis CI.
+# This happens as examples will use Plots.jl to make plots and movies.
+# See: https://github.com/jheinen/GR.jl/issues/278
+ENV["GKSwstype"] = "100"
 
 #####
 ##### Generate examples

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -3,8 +3,10 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FourierFlows = "2aec4490-903f-5c70-9b11-9bed06a700e1"
 GeophysicalFlows = "44ee3b1c-bc02-53fa-8355-8e347616e15e"
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 
 [compat]
-FFTW = "≥ 0.4.1"
+FourierFlows = "≥ 0.4.4"

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -179,7 +179,7 @@ nothing # hide
 plot(kr, abs.(Ehr),
       linewidth = 2,
       alpha = 0.7,
-      xlabel = L"$k_r$", ylabel = L"\int \| \hat E \| k_r \mathrm{d} k_{\theta}",
+      xlabel = L"k_r", ylabel = L"\int \| \hat E \| k_r \mathrm{d} k_{\theta}",
       xlims = (5e-1, gr.nx),
       xscale = :log10, yscale = :log10,
       title = "Radial energy spectrum",

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -5,8 +5,8 @@
 #
 # A simulations of decaying two-dimensional turbulence.
 
-using FourierFlows, PyPlot, Printf, Random
-
+using FourierFlows, Printf, Random, Plots, LaTeXStrings
+ 
 using Random: seed!
 using FFTW: rfft, irfft
 
@@ -25,13 +25,13 @@ nothing # hide
 #
 # First, we pick some numerical and physical parameters for our model.
 
-n, L  = 128, 2π             # grid resolution and domain length
+n, L  = 256, 2π             # grid resolution and domain length
 nothing # hide
 
 ## Then we pick the time-stepper parameters
-    dt = 1e-2  # timestep
-nsteps = 4000  # total number of steps
- nsubs = 1000  # number of steps between each plot
+    dt = 5e-3  # timestep
+nsteps = 8000  # total number of steps
+ nsubs = 40    # number of steps between each plot
 nothing # hide
 
 
@@ -42,8 +42,8 @@ prob = TwoDNavierStokes.Problem(; nx=n, Lx=L, ny=n, Ly=L, dt=dt, stepper="Filter
 nothing # hide
 
 # Next we define some shortcuts for convenience.
-sol, cl, vs, gr, filter = prob.sol, prob.clock, prob.vars, prob.grid, prob.timestepper.filter
-x, y = gridpoints(gr)
+sol, cl, vs, gr = prob.sol, prob.clock, prob.vars, prob.grid
+x, y = gr.x, gr.y
 nothing # hide
 
 
@@ -52,24 +52,25 @@ nothing # hide
 # Our initial condition closely tries to reproduce the initial condition used
 # in the paper by McWilliams (_JFM_, 1984)
 seed!(1234)
-k0, E0 = 6, 0.5
-zetai  = peakedisotropicspectrum(gr, k0, E0, mask=filter)
-TwoDNavierStokes.set_zeta!(prob, zetai)
+k₀, E₀ = 6, 0.5
+ζ₀ = peakedisotropicspectrum(gr, k₀, E₀, mask=prob.timestepper.filter)
+TwoDNavierStokes.set_zeta!(prob, ζ₀)
 nothing # hide
 
 # Let's plot the initial vorticity field:
-
-fig = figure(figsize=(3, 2), dpi=150)
-pcolormesh(x, y, vs.zeta)
-axis("square")
-xticks(-2:2:2)
-yticks(-2:2:2)
-title(L"initial vorticity $\zeta = \partial_x v - \partial_y u$")
-colorbar()
-clim(-40, 40)
-axis("off")
-gcf() # hide
-
+heatmap(x, y, vs.zeta,
+         aspectratio = 1,
+              c = :balance,
+           clim = (-40, 40),
+          xlims = (-L/2, L/2),
+          ylims = (-L/2, L/2),
+         xticks = -3:3,
+         yticks = -3:3,
+         xlabel = "x",
+         ylabel = "y",
+          title = "initial vorticity",
+     framestyle = :box)
+            
 
 # ## Diagnostics
 
@@ -104,29 +105,33 @@ nothing # hide
 
 # ## Visualizing the simulation
 
-# We define a function that plots the vorticity field and the evolution of
+# We initialize a plot with the vorticity field and the time-series of
 # energy and enstrophy diagnostics.
 
-function plot_output(prob, fig, axs; drawcolorbar=false)
-  TwoDNavierStokes.updatevars!(prob)
-  sca(axs[1])
-  pcolormesh(x, y, vs.zeta)
-  title("Vorticity")
-  clim(-40, 40)
-  axis("off")
-  axis("square")
-  if drawcolorbar==true
-    colorbar()
-  end
+l = @layout grid(1, 2)
 
-  sca(axs[2])
-  cla()
-  plot(E.t[1:E.i], E.data[1:E.i]/E.data[1], label="energy \$E(t)/E(0)\$")
-  plot(Z.t[1:Z.i], Z.data[1:E.i]/Z.data[1], label="enstrophy \$Z(t)/Z(0)\$")
-  xlabel(L"t")
-  ylabel(L"\Delta E, \, \Delta Z")
-end
-nothing # hide
+p1 = heatmap(x, y, vs.zeta,
+          aspectratio = 1,
+               c = :balance,
+            clim = (-40, 40),
+           xlims = (-L/2, L/2),
+           ylims = (-L/2, L/2),
+          xticks = -3:3,
+          yticks = -3:3,
+          xlabel = "x",
+          ylabel = "y",
+           title = "vorticity, t="*@sprintf("%.2f", cl.t),
+      framestyle = :box)
+
+p2 = plot(2, # this means "a plot with two series"
+         label=["energy E(t)/E(0)" "enstrophy Z(t)/Z(0)"],
+         linewidth=2,
+         alpha=0.7,
+         xlabel = "t",
+         xlims = (0, 41),
+         ylims = (0, 1.1))
+
+p = plot(p1, p2, layout=l, size = (900, 400))
 
 
 # ## Time-stepping the `Problem` forward
@@ -134,29 +139,30 @@ nothing # hide
 # We time-step the `Problem` forward in time.
 
 startwalltime = time()
-while cl.step < nsteps
-  stepforward!(prob, diags, nsubs)
-  saveoutput(out)
 
+anim = @animate for j = 0:Int(nsteps/nsubs)
+    
   log = @sprintf("step: %04d, t: %d, ΔE: %.4f, ΔZ: %.4f, walltime: %.2f min",
-    cl.step, cl.t, E.data[E.i]/E.data[1], Z.data[Z.i]/Z.data[1], (time()-startwalltime)/60)
+      cl.step, cl.t, E.data[E.i]/E.data[1], Z.data[Z.i]/Z.data[1], (time()-startwalltime)/60)
+  
+  if j%(1000/nsubs)==0; println(log) end  
 
-  println(log)
+  p[1][1][:z] = vs.zeta
+  p[1][:title] = "vorticity, t="*@sprintf("%.2f", cl.t)
+  push!(p[2][1], E.t[E.i], E.data[E.i]/E.data[1])
+  push!(p[2][2], Z.t[Z.i], Z.data[Z.i]/Z.data[1])
+
+  stepforward!(prob, diags, nsubs)
+  TwoDNavierStokes.updatevars!(prob)  
+  
 end
 println("finished")
 
+mp4(anim, "twodturb.mp4", fps=18)
 
-# ## Plot
-# Now let's see what we got. We plot the output,
 
-fig, axs = subplots(ncols=2, nrows=1, figsize=(12, 4), dpi=200)
-plot_output(prob, fig, axs; drawcolorbar=true)
-gcf() # hide
-
-# and finally save the figure
-
-savename = @sprintf("%s_%09d.png", joinpath(plotpath, plotname), cl.step)
-savefig(savename, dpi=240)
+# Last we save the output.
+saveoutput(out)
 
 
 # ## Radial energy spectrum
@@ -170,26 +176,11 @@ kr, Ehr = FourierFlows.radialspectrum(Eh, gr, refinement=1) # compute radial spe
 nothing # hide
 
 # and we plot it.
-
-fig2, axs = subplots(ncols=2, figsize=(12, 4), dpi=200)
-
-sca(axs[1])
-pcolormesh(x, y, vs.zeta)
-xlabel(L"x")
-ylabel(L"y")
-title("Vorticity")
-colorbar()
-clim(-40, 40)
-axis("off")
-axis("square")
-
-sca(axs[2])
-plot(kr, abs.(Ehr))
-xlabel(L"k_r")
-ylabel(L"\int | \hat{E} | \, k_r \,\mathrm{d} k_{\theta}")
-title("Radial energy spectrum")
-
-axs[2].set_xscale("log")
-axs[2].set_yscale("log")
-axs[2].set_xlim(5e-1, gr.nx)
-gcf() # hide
+plot(kr, abs.(Ehr),
+      linewidth = 2,
+      alpha = 0.7,
+      xlabel = L"$k_r$", ylabel = L"\int \| \hat E \| k_r \mathrm{d} k_{\theta}",
+      xlims = (5e-1, gr.nx),
+      xscale = :log10, yscale = :log10,
+      title = "Radial energy spectrum",
+      legend = false)

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -177,10 +177,10 @@ nothing # hide
 
 # and we plot it.
 plot(kr, abs.(Ehr),
-      linewidth = 2,
-      alpha = 0.7,
-      xlabel = L"k_r", ylabel = L"\int \| \hat E \| k_r \mathrm{d} k_{\theta}",
-      xlims = (5e-1, gr.nx),
-      xscale = :log10, yscale = :log10,
-      title = "Radial energy spectrum",
-      legend = false)
+    linewidth = 2,
+        alpha = 0.7,
+       xlabel = L"k_r", ylabel = L"\int \| \hat E \| k_r \mathrm{d} k_{\theta}",
+        xlims = (5e-1, gr.nx),
+       xscale = :log10, yscale = :log10,
+        title = "Radial energy spectrum",
+       legend = false)

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -6,8 +6,12 @@
 # A simulation of forced-dissipative two-dimensional turbulence. We solve the 
 # two-dimensional vorticity equation with linear drag and stochastic excitation.
 
-using FourierFlows, Printf, Plots, LaTeXStrings
-
+using
+  FourierFlows,
+  Printf,
+  Plots,
+  LaTeXStrings
+  
 using Random: seed!
 using FFTW: irfft
 
@@ -26,7 +30,7 @@ nothing # hide
 # First, we pick some numerical and physical parameters for our model.
 
  n, L  = 256, 2π             # grid resolution and domain length
- ν, nν = 1e-7, 2             # hyperviscosity coefficient and order
+ ν, nν = 2e-7, 2             # hyperviscosity coefficient and order
  μ, nμ = 1e-1, 0             # linear drag coefficient
 dt, tf = 0.005, 0.2/μ        # timestep and final time
     nt = round(Int, tf/dt)   # total timesteps
@@ -86,16 +90,17 @@ nothing # hide
 calcF!(v.Fh, sol, 0.0, cl, v, p, g)
 
 heatmap(x, y, irfft(v.Fh, g.nx),
-       aspectratio = 1,
-            c = :balance,
-         clim = (-200, 200),
-        xlims = (-L/2, L/2),
-        ylims = (-L/2, L/2),
-       xticks = -3:3,
-       yticks = -3:3,
-       xlabel = "x",
-       ylabel = "y",
-        title = "a forcing realization",
+     aspectratio = 1,
+               c = :balance,
+            clim = (-200, 200),
+           xlims = (-L/2, L/2),
+           ylims = (-L/2, L/2),
+          xticks = -3:3,
+          yticks = -3:3,
+          xlabel = L"x",
+          ylabel = L"y",
+           title = "a forcing realization",
+   guidefontsize = 15,
       framestyle = :box)
 
 
@@ -149,9 +154,10 @@ function computetendencies_and_makeplot(prob, diags)
              ylims = (-L/2, L/2),
             xticks = -3:3,
             yticks = -3:3,
-            xlabel = "x",
-            ylabel = "y",
-             title = "∇²ψ(x, y, t="*@sprintf("%.2f", cl.t)*")",
+            xlabel = L"x",
+            ylabel = L"y",
+             # title = L"\nabla^\psi(x, y, t="*@sprintf("%.2f", cl.t)*")",
+     guidefontsize = 15,
         framestyle = :box)
 
   p2 = plot(μ*t, [W[ii2] ε.+0*t -D[ii] -R[ii]],
@@ -159,22 +165,25 @@ function computetendencies_and_makeplot(prob, diags)
          linestyle = [:solid :dash :solid :solid],
          linewidth = 2,
              alpha = 0.8,
-            xlabel = "μt",
-            ylabel = "energy sources and sinks")
+            xlabel = L"\mu t",
+            ylabel = "energy sources and sinks",
+     guidefontsize = 15)
 
   p3 = plot(μ*t, [dEdt_computed[ii], dEdt_numerical],
              label = ["computed W-D" "numerical dE/dt"],
-         linestyle = [:solid :dashdotdot],
-         linewidth = 2,
+         linestyle = [:solid :dash],
+         linewidth = [2 3],
              alpha = 0.8,
-            xlabel = "μt",
-            ylabel = "dE/dt")
+            xlabel = L"\mu t",
+            ylabel = L"\mathrm{d}E/\mathrm{d}t",
+     guidefontsize = 15)
 
   p4 = plot(μ*t, residual,
              label = "residual dE/dt = computed - numerical",
          linewidth = 2,
              alpha = 0.7,
-            xlabel = "μt")
+            xlabel = L"\mu t",
+     guidefontsize = 15)
 
   p = plot(p1, p2, p3, p4, layout=l, size = (900, 800))
   return p

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,11 +8,11 @@ function lambdipole(U, R, g::AbstractGrid{T, A}; center=(mean(g.x), mean(g.y))) 
   firstzero = 3.8317059702075123156
   k = firstzero/R # dipole wavenumber for radius R in terms of first zero of besselj
   q0 = -2U*k/besselj(0, k*R) # dipole amplitude for strength U and radius R
-
+  x, y = gridpoints(g)
   xc, yc = center
-  r = @. sqrt( (g.x-xc)^2 + (g.y-yc)^2 )
+  r = @. sqrt( (x-xc)^2 + (y-yc)^2 )
   besselj1 = A([besselj(1, k*r[i, j]) for i=1:g.nx, j=1:g.ny])
-  q = @. q0 * besselj1 * (g.y-yc)/r
+  q = @. q0 * besselj1 * (y-yc)/r
   @. q[r >= R] = 0
   q
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,6 +72,7 @@ for dev in devices
     @test test_bqg_formstress(0.01, "ForwardEuler", dev)
     @test test_bqg_energyenstrophy(dev)
     @test test_bqg_meanenergyenstrophy(dev)
+    @test test_bqg_problemtype(Float32)
     @test BarotropicQG.nothingfunction() == nothing
   end
 

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -318,3 +318,9 @@ function test_bqg_meanenergyenstrophy(dev::Device=CPU())
     isapprox(enstrophyzeta0, enstrophy_calc, rtol=rtol_barotropicQG)
   )
 end
+
+function test_bqg_problemtype(T=Float32)
+  prob = BarotropicQG.Problem(T=T)
+
+  (typeof(prob.sol)==Array{Complex{T},2} && typeof(prob.grid.Lx)==T && eltype(prob.grid.x)==T && typeof(prob.vars.u)==Array{T,2})
+end

--- a/test/test_barotropicqgql.jl
+++ b/test/test_barotropicqgql.jl
@@ -261,5 +261,5 @@ end
 function test_bqgql_problemtype(T=Float32)
   prob = BarotropicQGQL.Problem(T=T)
 
-  (typeof(prob.sol)==Array{Complex{T},2} && typeof(prob.grid.Lx)==T && typeof(prob.grid.x)==Array{T,2} && typeof(prob.vars.u)==Array{T,2})
+  (typeof(prob.sol)==Array{Complex{T},2} && typeof(prob.grid.Lx)==T && eltype(prob.grid.x)==T && typeof(prob.vars.u)==Array{T,2})
 end

--- a/test/test_multilayerqg.jl
+++ b/test/test_multilayerqg.jl
@@ -173,8 +173,8 @@ function test_mqg_nonlinearadvection(dt, stepper; n=128, L=2π, nlayers=2, μ=0.
   β = 0.35
 
   U1, U2 = 0.1, 0.05
-  u1 = @. 0.5sech(gr.y/(Ly/15))^2
-  u2 = @. 0.02cos(3l0*gr.y)
+  u1 = @. 0.5sech(gr.y/(Ly/15))^2; u1 = reshape(u1, (1, gr.ny))
+  u2 = @. 0.02cos(3l0*gr.y); u2 = reshape(u2, (1, gr.ny))
   uyy1 = real.(ifft( -gr.l.^2 .* fft(u1) ))
   uyy2 = real.(ifft( -gr.l.^2 .* fft(u2) ))
 
@@ -256,8 +256,8 @@ function test_mqg_linearadvection(dt, stepper; n=128, L=2π, nlayers=2, μ=0.0, 
   β = 0.35
 
   U1, U2 = 0.1, 0.05
-  u1 = @. 0.5sech(gr.y/(Ly/15))^2
-  u2 = @. 0.02cos(3l0*gr.y)
+  u1 = @. 0.5sech(gr.y/(Ly/15))^2; u1 = reshape(u1, (1, gr.ny))
+  u2 = @. 0.02cos(3l0*gr.y); u2 = reshape(u2, (1, gr.ny))
   uyy1 = real.(ifft( -gr.l.^2 .* fft(u1) ))
   uyy2 = real.(ifft( -gr.l.^2 .* fft(u2) ))
 
@@ -273,7 +273,7 @@ function test_mqg_linearadvection(dt, stepper; n=128, L=2π, nlayers=2, μ=0.0, 
 
   ψ1, ψ2, q1, q2, ψ1x, ψ2x, q1x, q2x, Δψ2, Δq1, Δq2 = constructtestfields_2layer(gr)
 
-  Ff1 = (β .- uyy1 .-   25*(U2.+u2.-U1.-u1) ).*ψ1x + (U1.+u1).*q1x - ν*Δq1
+  Ff1 = (β .- uyy1 .- 25*(U2.+u2.-U1.-u1) ).*ψ1x + (U1.+u1).*q1x - ν*Δq1
   Ff2 = FourierFlows.jacobian(ψ2, η, gr) + (β .- uyy2 .- 25/4*(U1.+u1.-U2.-u2) ).*ψ2x + (U2.+u2).*(q2x + ηx) + μ*Δψ2 - ν*Δq2
 
   Ff = zeros(gr.nx, gr.ny, nlayers)
@@ -457,5 +457,5 @@ end
 function test_mqg_problemtype(T=Float32)
   prob = MultilayerQG.Problem(nlayers=2, T=T)
 
-  (typeof(prob.sol)==Array{Complex{T},3} && typeof(prob.grid.Lx)==T && typeof(prob.grid.x)==Array{T,2} && typeof(prob.vars.u)==Array{T,3})
+  (typeof(prob.sol)==Array{Complex{T},3} && typeof(prob.grid.Lx)==T && eltype(prob.grid.x)==T && typeof(prob.vars.u)==Array{T,3})
 end

--- a/test/test_twodnavierstokes.jl
+++ b/test/test_twodnavierstokes.jl
@@ -213,5 +213,5 @@ end
 function test_twodnavierstokes_problemtype(T=Float32, dev::Device=CPU())
   prob = TwoDNavierStokes.Problem(T=T, dev=dev)
 
-  (typeof(prob.sol)==Array{Complex{T},2} && typeof(prob.grid.Lx)==T && typeof(prob.grid.x)==Array{T,2} && typeof(prob.vars.u)==Array{T,2})
+  (typeof(prob.sol)==Array{Complex{T},2} && typeof(prob.grid.Lx)==T && eltype(prob.grid.x)==T && typeof(prob.vars.u)==Array{T,2})
 end


### PR DESCRIPTION
This is the beginning. We should ultimately drop PyPlot from docs/examples whatsoever.