### PR TITLE
Make test_energybudgets great again

### DIFF
--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -102,7 +102,7 @@ function test_bqg_stochasticforcingbudgets(dev::Device=CPU(); n=256, dt=0.01, L=
   # dEdt_computed = W[2:E.i] + ε - D[1:E.i-1] - R[1:E.i-1]      # Ito
   dEdt_computed = W[2:E.i] - D[1:E.i-1] - R[1:E.i-1]        # Stratonovich
 
-  return isapprox(mean(abs.(dEdt_numerical)), mean(abs.(dEdt_computed)), atol=1e-4)
+  return isapprox(dEdt_numerical, dEdt_computed, atol=1e-4)
 end
 
 """
@@ -150,7 +150,7 @@ function test_bqg_deterministicforcingbudgets(dev::Device=CPU(); n=256, dt=0.01,
   
   residual = dEdt_numerical - dEdt_computed
 
-  return isapprox(mean(abs.(dEdt_numerical)), mean(abs.(dEdt_computed)), atol=1e-10)
+  return isapprox(dEdt_numerical, dEdt_computed, atol=1e-10)
 end
 
 """

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -62,7 +62,7 @@ function test_bqg_stochasticforcingbudgets(dev::Device=CPU(); n=256, dt=0.01, L=
   kf, dkf = 12.0, 2.0
   ε = 0.1
 
-  CUDA.@allowscalar Kr = ArrayType(dev)([ gr.kr[i] for i=1:gr.nkr, j=1:gr.nl ])
+  CUDA.@allowscalar Kr = ArrayType(dev)([gr.kr[i] for i=1:gr.nkr, j=1:gr.nl])
 
   forcingcovariancespectrum = zeros(dev, T, (gr.nkr, gr.nl))
   @. forcingcovariancespectrum = exp( -(sqrt(gr.Krsq) - kf)^2 / (2 * dkf^2) )
@@ -74,8 +74,8 @@ function test_bqg_stochasticforcingbudgets(dev::Device=CPU(); n=256, dt=0.01, L=
 
   Random.seed!(1234)
 
-  function calcFq!(Fqh, sol, t, cl, v, p, g)
-    eta = ArrayType(dev)(exp.(2π*im*rand(T, size(sol)))/sqrt(cl.dt))
+  function calcFq!(Fqh, sol, t, clock, vars, params, grid)
+    eta = ArrayType(dev)(exp.(2π * im * rand(T, size(sol))) / sqrt(clock.dt))
     CUDA.@allowscalar eta[1, 1] = 0
     @. Fqh = eta * sqrt(forcingcovariancespectrum)
     return nothing
@@ -84,8 +84,6 @@ function test_bqg_stochasticforcingbudgets(dev::Device=CPU(); n=256, dt=0.01, L=
   prob = BarotropicQG.Problem(dev; nx=n, Lx=L, ν=ν, nν=nν, μ=μ, dt=dt,
    stepper="RK4", calcFq=calcFq!, stochastic=true)
 
-  sol, cl, v, p, g = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-
   BarotropicQG.set_zeta!(prob, 0*x)
   E = Diagnostic(BarotropicQG.energy,      prob, nsteps=nt)
   D = Diagnostic(BarotropicQG.dissipation, prob, nsteps=nt)
@@ -93,28 +91,21 @@ function test_bqg_stochasticforcingbudgets(dev::Device=CPU(); n=256, dt=0.01, L=
   W = Diagnostic(BarotropicQG.work,        prob, nsteps=nt)
   diags = [E, D, W, R]
 
-  # Step forward
-
   stepforward!(prob, diags, nt)
 
   BarotropicQG.updatevars!(prob)
 
-  E, D, W, R = diags
-
-  t = round(μ*cl.t, digits=2)
-
   i₀ = 1
-  dEdt = (E[(i₀+1):E.i] - E[i₀:E.i-1])/cl.dt
+  dEdt_numerical = (E[(i₀+1):E.i] - E[i₀:E.i-1]) / prob.clock.dt
   ii = (i₀):E.i-1
   ii2 = (i₀+1):E.i
 
-  # dEdt = W - D - R?
   # If the Ito interpretation was used for the work
   # then we need to add the drift term
-  # total = W[ii2]+ε - D[ii] - R[ii]      # Ito
-  total = W[ii2] - D[ii] - R[ii]        # Stratonovich
+  # dEdt_computed = W[ii2] + ε - D[ii] - R[ii]    # Ito
+  dEdt_computed = W[ii2] - D[ii] - R[ii]        # Stratonovich
 
-  residual = dEdt - total
+  residual = dEdt_numerical - dEdt_computed
 
   isapprox(mean(abs.(residual)), 0, atol=1e-4)
 end
@@ -139,43 +130,34 @@ function test_bqg_deterministicforcingbudgets(dev::Device=CPU(); n=256, dt=0.01,
   f = @. 0.01 * cos(4k₀*x) * cos(5l₀*y)
   fh = rfft(f)
   
-  function calcFq!(Fqh, sol, t, cl, v, p, g)
-    cos2t = cos(2*t)
-    @. Fqh = fh*cos2t
+  function calcFq!(Fqh, sol, t, clock, vars, params, grid)
+    @. Fqh = fh * cos(2t)
     return nothing
   end
 
   prob = BarotropicQG.Problem(dev; nx=n, Lx=L, ν=ν, nν=nν, μ=μ, dt=dt,
    stepper="RK4", calcFq=calcFq!, stochastic=false)
 
-  sol, cl, v, p, g = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-
   BarotropicQG.set_zeta!(prob, 0*x)
+  
   E = Diagnostic(BarotropicQG.energy,      prob, nsteps=nt)
   D = Diagnostic(BarotropicQG.dissipation, prob, nsteps=nt)
   R = Diagnostic(BarotropicQG.drag,        prob, nsteps=nt)
   W = Diagnostic(BarotropicQG.work,        prob, nsteps=nt)
   diags = [E, D, W, R]
 
-  # Step forward
-
   stepforward!(prob, diags, round(Int, nt))
 
   BarotropicQG.updatevars!(prob)
 
-  E, D, W, R = diags
-
-  t = round(μ*cl.t, digits=2)
-
   i₀ = 1
-  dEdt = (E[(i₀+1):E.i] - E[i₀:E.i-1])/cl.dt
+  dEdt_numerical = (E[(i₀+1):E.i] - E[i₀:E.i-1]) / prob.clock.dt
   ii = (i₀):E.i-1
   ii2 = (i₀+1):E.i
 
-  # dEdt = W - D - R?
-  total = W[ii2] - D[ii] - R[ii]
+  dEdt_computed = W[ii2] - D[ii] - R[ii]
 
-  residual = dEdt - total
+  residual = dEdt_numerical - dEdt_computed
 
   return isapprox(mean(abs.(residual)), 0, atol=1e-8)
 end

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -95,19 +95,14 @@ function test_bqg_stochasticforcingbudgets(dev::Device=CPU(); n=256, dt=0.01, L=
 
   BarotropicQG.updatevars!(prob)
 
-  i₀ = 1
-  dEdt_numerical = (E[(i₀+1):E.i] - E[i₀:E.i-1]) / prob.clock.dt
-  ii = (i₀):E.i-1
-  ii2 = (i₀+1):E.i
+  dEdt_numerical = (E[2:E.i] - E[1:E.i-1]) / prob.clock.dt
 
   # If the Ito interpretation was used for the work
   # then we need to add the drift term
-  # dEdt_computed = W[ii2] + ε - D[ii] - R[ii]    # Ito
-  dEdt_computed = W[ii2] - D[ii] - R[ii]        # Stratonovich
+  # dEdt_computed = W[2:E.i] + ε - D[1:E.i-1] - R[1:E.i-1]      # Ito
+  dEdt_computed = W[2:E.i] - D[1:E.i-1] - R[1:E.i-1]        # Stratonovich
 
-  residual = dEdt_numerical - dEdt_computed
-
-  isapprox(mean(abs.(residual)), 0, atol=1e-4)
+  return isapprox(mean(abs.(dEdt_numerical)), mean(abs.(dEdt_computed)), atol=1e-4)
 end
 
 """
@@ -150,16 +145,12 @@ function test_bqg_deterministicforcingbudgets(dev::Device=CPU(); n=256, dt=0.01,
 
   BarotropicQG.updatevars!(prob)
 
-  i₀ = 1
-  dEdt_numerical = (E[(i₀+1):E.i] - E[i₀:E.i-1]) / prob.clock.dt
-  ii = (i₀):E.i-1
-  ii2 = (i₀+1):E.i
-
-  dEdt_computed = W[ii2] - D[ii] - R[ii]
-
+  dEdt_numerical = (E[3:E.i] - E[1:E.i-2]) / (2 * prob.clock.dt)
+  dEdt_computed  = W[2:E.i-1] - D[2:E.i-1] - R[2:E.i-1]
+  
   residual = dEdt_numerical - dEdt_computed
 
-  return isapprox(mean(abs.(residual)), 0, atol=1e-8)
+  return isapprox(mean(abs.(dEdt_numerical)), mean(abs.(dEdt_computed)), atol=1e-10)
 end
 
 """

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -102,7 +102,7 @@ function test_bqg_stochasticforcingbudgets(dev::Device=CPU(); n=256, dt=0.01, L=
   # dEdt_computed = W[2:E.i] + ε - D[1:E.i-1] - R[1:E.i-1]      # Ito
   dEdt_computed = W[2:E.i] - D[1:E.i-1] - R[1:E.i-1]        # Stratonovich
 
-  return isapprox(dEdt_numerical, dEdt_computed, atol=1e-4)
+  return isapprox(dEdt_numerical, dEdt_computed, rtol=1e-3)
 end
 
 """

--- a/test/test_barotropicqgql.jl
+++ b/test/test_barotropicqgql.jl
@@ -95,19 +95,14 @@ function test_bqgql_stochasticforcingbudgets(dev::Device=CPU(); n=256, dt=0.01, 
 
   BarotropicQGQL.updatevars!(prob)
   
-  i₀ = 1
-  dEdt_numerical = (E[(i₀+1):E.i] - E[i₀:E.i-1]) / prob.clock.dt
-  ii = (i₀):E.i-1
-  ii2 = (i₀+1):E.i
+  dEdt_numerical = (E[2:E.i] - E[1:E.i-1]) / prob.clock.dt
 
   # If the Ito interpretation was used for the work
   # then we need to add the drift term
-  # dEdt_computed = W[ii2] + ε - D[ii] - R[ii]    # Ito
-  dEdt_computed = W[ii2] - D[ii] - R[ii]        # Stratonovich
+  # dEdt_computed = W[2:E.i] + ε - D[1:E.i-1] - R[1:E.i-1]      # Ito
+  dEdt_computed = W[2:E.i] - D[1:E.i-1] - R[1:E.i-1]        # Stratonovich
 
-  residual = dEdt_numerical - dEdt_computed
-
-  return isapprox(mean(abs.(residual)), 0, atol=1e-4)
+  return isapprox(mean(abs.(dEdt_numerical)), mean(abs.(dEdt_computed)), atol=1e-4)
 end
 
 """
@@ -150,16 +145,12 @@ function test_bqgql_deterministicforcingbudgets(dev::Device=CPU(); n=256, dt=0.0
 
   BarotropicQGQL.updatevars!(prob)
 
-  i₀ = 1
-  dEdt_numerical = (E[(i₀+1):E.i] - E[i₀:E.i-1]) / prob.clock.dt
-  ii = (i₀):E.i-1
-  ii2 = (i₀+1):E.i
-
-  dEdt_computed = W[ii2] - D[ii] - R[ii]
-
+  dEdt_numerical = (E[3:E.i] - E[1:E.i-2]) / (2 * prob.clock.dt)
+  dEdt_computed  = W[2:E.i-1] - D[2:E.i-1] - R[2:E.i-1]
+  
   residual = dEdt_numerical - dEdt_computed
 
-  return isapprox(mean(abs.(residual)), 0, atol=1e-8)
+  return isapprox(mean(abs.(dEdt_numerical)), mean(abs.(dEdt_computed)), atol=1e-10)
 end
 
 """

--- a/test/test_barotropicqgql.jl
+++ b/test/test_barotropicqgql.jl
@@ -102,7 +102,7 @@ function test_bqgql_stochasticforcingbudgets(dev::Device=CPU(); n=256, dt=0.01, 
   # dEdt_computed = W[2:E.i] + ε - D[1:E.i-1] - R[1:E.i-1]      # Ito
   dEdt_computed = W[2:E.i] - D[1:E.i-1] - R[1:E.i-1]        # Stratonovich
 
-  return isapprox(mean(abs.(dEdt_numerical)), mean(abs.(dEdt_computed)), atol=1e-4)
+  return isapprox(dEdt_numerical, dEdt_computed, atol=1e-4)
 end
 
 """
@@ -150,7 +150,7 @@ function test_bqgql_deterministicforcingbudgets(dev::Device=CPU(); n=256, dt=0.0
   
   residual = dEdt_numerical - dEdt_computed
 
-  return isapprox(mean(abs.(dEdt_numerical)), mean(abs.(dEdt_computed)), atol=1e-10)
+  return isapprox(dEdt_numerical, dEdt_computed, atol=1e-10)
 end
 
 """

--- a/test/test_twodnavierstokes.jl
+++ b/test/test_twodnavierstokes.jl
@@ -124,7 +124,7 @@ function test_twodnavierstokes_stochasticforcing_enstrophybudget(dev::Device=CPU
   # dZdt_computed = W[2:Z.i] + εᶻ - D[1:Z.i-1] - R[1:Z.i-1]      # Ito
   dZdt_computed = W[2:Z.i] - D[1:Z.i-1] - R[1:Z.i-1]        # Stratonovich
 
-  return isapprox(dZdt_numerical, dZdt_computed, rtol = 1e-4)
+  return isapprox(dZdt_numerical, dZdt_computed, rtol = 1e-3)
 end
 
 function test_twodnavierstokes_deterministicforcing_energybudget(dev::Device=CPU(); n=256, dt=0.01, L=2π, ν=1e-7, nν=2, μ=1e-1, nμ=0)

--- a/test/test_twodnavierstokes.jl
+++ b/test/test_twodnavierstokes.jl
@@ -64,18 +64,14 @@ function test_twodnavierstokes_stochasticforcingbudgets(dev::Device=CPU(); n=256
   
   TwoDNavierStokes.updatevars!(prob)
 
-  i₀ = 1
-  dEdt_numerical = (E[(i₀+1):E.i] - E[i₀:E.i-1]) / prob.clock.dt
-  ii  = (i₀):E.i-1
-  ii2 = (i₀+1):E.i
+  dEdt_numerical = (E[2:E.i] - E[1:E.i-1]) / prob.clock.dt
 
   # If the Ito interpretation was used for the work
   # then we need to add the drift term
-  # dEdt_computed = W[ii2] + ε - D[ii] - R[ii]      # Ito
-  dEdt_computed = W[ii2] - D[ii] - R[ii]        # Stratonovich
+  # dEdt_computed = W[2:E.i] + ε - D[1:E.i-1] - R[1:E.i-1]      # Ito
+  dEdt_computed = W[2:E.i] - D[1:E.i-1] - R[1:E.i-1]        # Stratonovich
 
-  residual = dEdt_numerical - dEdt_computed
-  isapprox(mean(abs.(residual)), 0, atol=1e-4)
+  return isapprox(mean(abs.(dEdt_numerical)), mean(abs.(dEdt_computed)), atol=1e-4)
 end
 
 
@@ -112,16 +108,10 @@ function test_twodnavierstokes_deterministicforcingbudgets(dev::Device=CPU(); n=
   
   TwoDNavierStokes.updatevars!(prob)
 
-  i₀ = 1
-  dEdt_numerical = (E[(i₀+1):E.i] - E[i₀:E.i-1]) / prob.clock.dt
-  ii  = (i₀):E.i-1
-  ii2 = (i₀+1):E.i
+  dEdt_numerical = (E[3:E.i] - E[1:E.i-2]) / (2 * prob.clock.dt)
+  dEdt_computed  = W[2:E.i-1] - D[2:E.i-1] - R[2:E.i-1]
 
-  dEdt_computed = W[ii2] - D[ii] - R[ii]
-  
-  residual = dEdt_numerical - dEdt_computed
-  
-  return isapprox(mean(abs.(residual)), 0, atol=1e-8)
+  return isapprox(mean(abs.(dEdt_numerical)), mean(abs.(dEdt_computed)), atol=1e-10)
 end
 
 """


### PR DESCRIPTION
Fixes #104 --- a `.` was missing! :)

This PR also changes the way numerical tendencies for energy/enstrophy budget are computed for deterministic forcing tests. Now tendencies are computed via second-order accurate centered finite differences (instead of first-order forward difference) giving smaller residuals. This will not increase accuracy in the stochastically forced cases since forcing is temporally delta-correlated.
