### PR TITLE
Make all tests/functions gpu-kernel friendly

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,7 +13,7 @@ function lambdipole(U, R, grid::TwoDGrid{T, A}; center=(mean(grid.x), mean(grid.
   r = @. sqrt( (x - xc)^2 + (y - yc)^2 )
   CUDA.@allowscalar besselj1 = A([besselj(1, k * r[i, j]) for i=1:grid.nx, j=1:grid.ny])
   q = @. q0 * besselj1 * (y - yc) / r
-  CUDA.@allowscalar @. q[r >= R] = 0
+  @. q = ifelse(r >= R, 0, q)
   return q
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,48 +115,24 @@ for dev in devices
     @test SurfaceQG.nothingfunction() == nothing
   end
   
-  if dev == CPU()
-    @testset "MultilayerQG" begin
-      include("test_multilayerqg.jl")
-      
-      @test test_pvtofromstreamfunction_2layer(dev)
-      @test test_pvtofromstreamfunction_3layer(dev)
-      @test test_mqg_rossbywave("RK4", 1e-2, 20, dev)
-      @test test_mqg_nonlinearadvection(0.005, "ForwardEuler", dev)
-      @test test_mqg_linearadvection(0.005, "ForwardEuler", dev)
-      @test test_mqg_energies(dev)
-      @test test_mqg_energysinglelayer(dev)
-      @test test_mqg_fluxes(dev)
-      @test test_mqg_fluxessinglelayer(dev)
-      @test test_mqg_setqsetψ(dev)
-      @test test_mqg_paramsconstructor(dev)
-      @test test_mqg_stochasticforcedproblemconstructor(dev)
-      @test test_mqg_problemtype(dev, Float32)
-      @test MultilayerQG.nothingfunction() == nothing
-    end
+  @testset "MultilayerQG" begin
+    include("test_multilayerqg.jl")
+    
+    @test test_pvtofromstreamfunction_2layer(dev)
+    @test test_pvtofromstreamfunction_3layer(dev)
+    @test test_mqg_rossbywave("RK4", 1e-2, 20, dev)
+    @test test_mqg_nonlinearadvection(0.005, "ForwardEuler", dev)
+    @test test_mqg_linearadvection(0.005, "ForwardEuler", dev)
+    @test test_mqg_energies(dev)
+    @test test_mqg_energysinglelayer(dev)
+    @test test_mqg_fluxes(dev)
+    @test test_mqg_fluxessinglelayer(dev)
+    @test test_mqg_setqsetψ(dev)
+    @test test_mqg_paramsconstructor(dev)
+    @test test_mqg_stochasticforcedproblemconstructor(dev)
+    @test test_mqg_problemtype(dev, Float32)
+    @test MultilayerQG.nothingfunction() == nothing
   end
-end
-
-dev = CPU()
-println("following tests only on "*string(typeof(dev)))
-
-@testset "MultilayerQG" begin
-  include("test_multilayerqg.jl")
-  
-  @test test_pvtofromstreamfunction_2layer(dev)
-  @test test_pvtofromstreamfunction_3layer(dev)
-  @test test_mqg_rossbywave("RK4", 1e-2, 20, dev)
-  @test test_mqg_nonlinearadvection(0.005, "ForwardEuler", dev)
-  @test test_mqg_linearadvection(0.005, "ForwardEuler", dev)
-  @test test_mqg_energies(dev)
-  @test test_mqg_energysinglelayer(dev)
-  @test test_mqg_fluxes(dev)
-  @test test_mqg_fluxessinglelayer(dev)
-  @test test_mqg_setqsetψ(dev)
-  @test test_mqg_paramsconstructor(dev)
-  @test test_mqg_stochasticforcedproblemconstructor(dev)
-  @test test_mqg_problemtype(dev, Float32)
-  @test MultilayerQG.nothingfunction() == nothing
 end
 
 end # time

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -65,8 +65,8 @@ function test_bqg_stochasticforcing_energybudget(dev::Device=CPU(); n=256, dt=0.
   
   forcing_spectrum = zeros(dev, T, (grid.nkr, grid.nl))
   @. forcing_spectrum = exp(-(K - kf)^2 / (2 * dkf^2))
-  @. forcing_spectrum = ifelse(gr.Krsq < 2^2,  0, forcing_spectrum)   # no power at low wavenumbers
-  @. forcing_spectrum = ifelse(gr.Krsq > 20^2, 0, forcing_spectrum)   # no power at high wavenumbers
+  @. forcing_spectrum = ifelse(grid.Krsq < 2^2,  0, forcing_spectrum)   # no power at low wavenumbers
+  @. forcing_spectrum = ifelse(grid.Krsq > 20^2, 0, forcing_spectrum)   # no power at high wavenumbers
   ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
   forcing_spectrum .= ε / ε0 * forcing_spectrum
 
@@ -172,8 +172,8 @@ function test_bqg_stochasticforcing_enstrophybudget(dev::Device=CPU(); n=256, dt
   
   forcing_spectrum = zeros(dev, T, (grid.nkr, grid.nl))
   @. forcing_spectrum = exp(-(K - kf)^2 / (2 * dkf^2))
-  @. forcing_spectrum = ifelse(gr.Krsq < 2^2,  0, forcing_spectrum)   # no power at low wavenumbers
-  @. forcing_spectrum = ifelse(gr.Krsq > 20^2, 0, forcing_spectrum)   # no power at high wavenumbers
+  @. forcing_spectrum = ifelse(grid.Krsq < 2^2,  0, forcing_spectrum)   # no power at low wavenumbers
+  @. forcing_spectrum = ifelse(grid.Krsq > 20^2, 0, forcing_spectrum)   # no power at high wavenumbers
   εᶻ0 = parsevalsum(forcing_spectrum / 2, grid) / (grid.Lx * grid.Ly)
   forcing_spectrum .= εᶻ / εᶻ0 * forcing_spectrum
 

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -65,8 +65,8 @@ function test_bqg_stochasticforcing_energybudget(dev::Device=CPU(); n=256, dt=0.
   
   forcing_spectrum = zeros(dev, T, (grid.nkr, grid.nl))
   @. forcing_spectrum = exp(-(K - kf)^2 / (2 * dkf^2))
-  CUDA.@allowscalar @. forcing_spectrum[K .<  2 * 2π/L] = 0    # no power at low wavenumbers
-  CUDA.@allowscalar @. forcing_spectrum[K .> 20 * 2π/L] = 0    # no power at high wavenumbers
+  @. forcing_spectrum = ifelse(gr.Krsq < 2^2,  0, forcing_spectrum)   # no power at low wavenumbers
+  @. forcing_spectrum = ifelse(gr.Krsq > 20^2, 0, forcing_spectrum)   # no power at high wavenumbers
   ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
   forcing_spectrum .= ε / ε0 * forcing_spectrum
 
@@ -172,8 +172,8 @@ function test_bqg_stochasticforcing_enstrophybudget(dev::Device=CPU(); n=256, dt
   
   forcing_spectrum = zeros(dev, T, (grid.nkr, grid.nl))
   @. forcing_spectrum = exp(-(K - kf)^2 / (2 * dkf^2))
-  CUDA.@allowscalar @. forcing_spectrum[K .<  2 * 2π/L] = 0    # no power at low wavenumbers
-  CUDA.@allowscalar @. forcing_spectrum[K .> 20 * 2π/L] = 0    # no power at high wavenumbers
+  @. forcing_spectrum = ifelse(gr.Krsq < 2^2,  0, forcing_spectrum)   # no power at low wavenumbers
+  @. forcing_spectrum = ifelse(gr.Krsq > 20^2, 0, forcing_spectrum)   # no power at high wavenumbers
   εᶻ0 = parsevalsum(forcing_spectrum / 2, grid) / (grid.Lx * grid.Ly)
   forcing_spectrum .= εᶻ / εᶻ0 * forcing_spectrum
 

--- a/test/test_barotropicqgql.jl
+++ b/test/test_barotropicqgql.jl
@@ -227,7 +227,7 @@ function test_bqgql_energyenstrophy(dev::Device=CPU())
   energyζ₀ = BarotropicQGQL.energy(prob)
   enstrophyζ₀ = BarotropicQGQL.enstrophy(prob)
 
-  return isapprox(energyζ₀, energy_calc, rtol=1e-13) && isapprox(enstrophyζ₀, enstrophy_calc, rtol=1e-13) && BarotropicQGQL.addforcing!(prob.timestepper.N, sol, cl.t, clock, vars, params, grid)==nothing
+  return isapprox(energyζ₀, energy_calc, rtol=1e-13) && isapprox(enstrophyζ₀, enstrophy_calc, rtol=1e-13) && BarotropicQGQL.addforcing!(prob.timestepper.N, sol, clock.t, clock, vars, params, grid)==nothing
 end
 
 function test_bqgql_problemtype(dev, T)

--- a/test/test_barotropicqgql.jl
+++ b/test/test_barotropicqgql.jl
@@ -63,20 +63,20 @@ function test_bqgql_stochasticforcingbudgets(dev::Device=CPU(); n=256, dt=0.01, 
   
   CUDA.@allowscalar Kr = ArrayType(dev)([ gr.kr[i] for i=1:gr.nkr, j=1:gr.nl])
 
-  forcingcovariancespectrum = zeros(dev, T, (gr.nkr, gr.nl))
-  @. forcingcovariancespectrum = exp(-(sqrt(gr.Krsq) - kf)^2 / (2 * dkf^2))
-  CUDA.@allowscalar @. forcingcovariancespectrum[gr.Krsq .< 2^2] = 0
-  CUDA.@allowscalar @. forcingcovariancespectrum[gr.Krsq .> 20^2] = 0
-  CUDA.@allowscalar @. forcingcovariancespectrum[Kr .< 2π/L] = 0
-  ε0 = parsevalsum(forcingcovariancespectrum .* gr.invKrsq / 2, gr) / (gr.Lx * gr.Ly)
-  forcingcovariancespectrum .= ε / ε0 * forcingcovariancespectrum
+  forcing_spectrum = zeros(dev, T, (gr.nkr, gr.nl))
+  @. forcing_spectrum = exp(-(sqrt(gr.Krsq) - kf)^2 / (2 * dkf^2))
+  @. forcing_spectrum = ifelse(gr.Krsq < 2^2, 0, forcing_spectrum)
+  @. forcing_spectrum = ifelse(gr.Krsq > 20^2, 0, forcing_spectrum)
+  @. forcing_spectrum = ifelse(Kr < 2π/L, 0, forcing_spectrum)
+  ε0 = parsevalsum(forcing_spectrum .* gr.invKrsq / 2, gr) / (gr.Lx * gr.Ly)
+  forcing_spectrum .= ε / ε0 * forcing_spectrum
 
   Random.seed!(1234)
 
   function calcF!(F, sol, t, clock, vars, params, grid)
     eta = ArrayType(dev)(exp.(2π * im * rand(T, size(sol))) / sqrt(clock.dt))
     CUDA.@allowscalar eta[1, 1] = 0
-    @. F = eta * sqrt(forcingcovariancespectrum)
+    @. F = eta * sqrt(forcing_spectrum)
     return nothing
   end
 

--- a/test/test_surfaceqg.jl
+++ b/test/test_surfaceqg.jl
@@ -177,9 +177,9 @@ function test_sqg_stochasticforcing_buoyancy_variance_budget(dev::Device=CPU(); 
 
   forcingcovariancespectrum = ArrayType(dev)(zero(grid.Krsq))
   @. forcingcovariancespectrum = exp(-(sqrt(grid.Krsq) - kf)^2 / (2 * dkf^2))
-  CUDA.@allowscalar @. forcingcovariancespectrum[grid.Krsq .< 2^2] = 0
-  CUDA.@allowscalar @. forcingcovariancespectrum[grid.Krsq .> 20^2] = 0
-  CUDA.@allowscalar @. forcingcovariancespectrum[Kr .< 2π/L] = 0
+  @. forcingcovariancespectrum = ifelse(gr.Krsq < 2^2, 0, forcingcovariancespectrum)
+  @. forcingcovariancespectrum = ifelse(gr.Krsq > 20^2, 0, forcingcovariancespectrum)
+  @. forcingcovariancespectrum = ifelse(Kr < 2π/L, 0, forcingcovariancespectrum)
   εᵇ0 = parsevalsum(forcingcovariancespectrum, grid) / (grid.Lx * grid.Ly)
   forcingcovariancespectrum .= εᵇ / εᵇ0 * forcingcovariancespectrum
   

--- a/test/test_twodnavierstokes.jl
+++ b/test/test_twodnavierstokes.jl
@@ -27,17 +27,17 @@ function test_twodnavierstokes_stochasticforcing_energybudget(dev::Device=CPU();
   kf, dkf = 12.0, 2.0
   ε = 0.1
 
-  gr  = TwoDGrid(dev, n, L)
-  x, y = gridpoints(gr)
+  grid = TwoDGrid(dev, n, L)
+  x, y = gridpoints(grid)
 
-  Kr = ArrayType(dev)([CUDA.@allowscalar gr.kr[i] for i=1:gr.nkr, j=1:gr.nl])
+  Kr = ArrayType(dev)([CUDA.@allowscalar grid.kr[i] for i=1:grid.nkr, j=1:grid.nl])
 
-  forcing_spectrum = ArrayType(dev)(zero(gr.Krsq))
-  @. forcing_spectrum = exp(-(sqrt(gr.Krsq) - kf)^2 / (2 * dkf^2))
-  @. forcing_spectrum = ifelse(gr.Krsq < 2^2, 0, forcing_spectrum)
-  @. forcing_spectrum = ifelse(gr.Krsq > 20^2, 0, forcing_spectrum)
+  forcing_spectrum = ArrayType(dev)(zero(grid.Krsq))
+  @. forcing_spectrum = exp(-(sqrt(grid.Krsq) - kf)^2 / (2 * dkf^2))
+  @. forcing_spectrum = ifelse(grid.Krsq < 2^2, 0, forcing_spectrum)
+  @. forcing_spectrum = ifelse(grid.Krsq > 20^2, 0, forcing_spectrum)
   @. forcing_spectrum = ifelse(Kr < 2π/L, 0, forcing_spectrum)
-  ε0 = parsevalsum(forcing_spectrum .* gr.invKrsq / 2, gr) / (gr.Lx * gr.Ly)
+  ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
   forcing_spectrum .= ε / ε0 * forcing_spectrum
 
   Random.seed!(1234)
@@ -54,7 +54,7 @@ function test_twodnavierstokes_stochasticforcing_energybudget(dev::Device=CPU();
 
   TwoDNavierStokes.set_zeta!(prob, 0*x)
   
-  E = Diagnostic(TwoDNavierStokes.energy,      prob, nsteps=nt)
+  E = Diagnostic(TwoDNavierStokes.energy,             prob, nsteps=nt)
   D = Diagnostic(TwoDNavierStokes.energy_dissipation, prob, nsteps=nt)
   R = Diagnostic(TwoDNavierStokes.energy_drag,        prob, nsteps=nt)
   W = Diagnostic(TwoDNavierStokes.energy_work,        prob, nsteps=nt)
@@ -81,17 +81,17 @@ function test_twodnavierstokes_stochasticforcing_enstrophybudget(dev::Device=CPU
   kf, dkf = 12.0, 2.0
   εᶻ = 0.1
 
-  gr  = TwoDGrid(dev, n, L)
-  x, y = gridpoints(gr)
+  grid = TwoDGrid(dev, n, L)
+  x, y = gridpoints(grid)
 
-  Kr = ArrayType(dev)([CUDA.@allowscalar gr.kr[i] for i=1:gr.nkr, j=1:gr.nl])
+  Kr = ArrayType(dev)([CUDA.@allowscalar grid.kr[i] for i=1:grid.nkr, j=1:grid.nl])
 
-  forcing_spectrum = ArrayType(dev)(zero(gr.Krsq))
-  @. forcing_spectrum = exp(-(sqrt(gr.Krsq) - kf)^2 / (2 * dkf^2))
-  @. forcing_spectrum = ifelse(gr.Krsq < 2^2, 0, forcing_spectrum)
-  @. forcing_spectrum = ifelse(gr.Krsq > 20^2, 0, forcing_spectrum)
+  forcing_spectrum = ArrayType(dev)(zero(grid.Krsq))
+  @. forcing_spectrum = exp(-(sqrt(grid.Krsq) - kf)^2 / (2 * dkf^2))
+  @. forcing_spectrum = ifelse(grid.Krsq < 2^2, 0, forcing_spectrum)
+  @. forcing_spectrum = ifelse(grid.Krsq > 20^2, 0, forcing_spectrum)
   @. forcing_spectrum = ifelse(Kr < 2π/L, 0, forcing_spectrum)
-  εᶻ0 = parsevalsum(forcing_spectrum / 2, gr) / (gr.Lx * gr.Ly)
+  εᶻ0 = parsevalsum(forcing_spectrum / 2, grid) / (grid.Lx * grid.Ly)
   forcing_spectrum .= εᶻ / εᶻ0 * forcing_spectrum
   
   Random.seed!(1234)
@@ -107,7 +107,7 @@ function test_twodnavierstokes_stochasticforcing_enstrophybudget(dev::Device=CPU
    stepper="RK4", calcF=calcF!, stochastic=true)
 
   TwoDNavierStokes.set_zeta!(prob, 0*x)
-  Z = Diagnostic(TwoDNavierStokes.enstrophy,      prob, nsteps=nt)
+  Z = Diagnostic(TwoDNavierStokes.enstrophy,             prob, nsteps=nt)
   D = Diagnostic(TwoDNavierStokes.enstrophy_dissipation, prob, nsteps=nt)
   R = Diagnostic(TwoDNavierStokes.enstrophy_drag,        prob, nsteps=nt)
   W = Diagnostic(TwoDNavierStokes.enstrophy_work,        prob, nsteps=nt)
@@ -134,8 +134,8 @@ function test_twodnavierstokes_deterministicforcing_energybudget(dev::Device=CPU
   dt, tf = 0.005, 0.1/μ
   nt = round(Int, tf/dt)
 
-  gr  = TwoDGrid(dev, n, L)
-  x, y = gridpoints(gr)
+  grid = TwoDGrid(dev, n, L)
+  x, y = gridpoints(grid)
 
   # Forcing = 0.01cos(4x)cos(5y)cos(2t)
   f = @. 0.01cos(4x) * cos(5y)
@@ -173,8 +173,8 @@ function test_twodnavierstokes_deterministicforcing_enstrophybudget(dev::Device=
   dt, tf = 0.005, 0.1/μ
   nt = round(Int, tf/dt)
 
-  gr  = TwoDGrid(dev, n, L)
-  x, y = gridpoints(gr)
+  grid = TwoDGrid(dev, n, L)
+  x, y = gridpoints(grid)
 
   # Forcing = 0.01cos(4x)cos(5y)cos(2t)
   f = @. 0.01cos(4x) * cos(5y)
@@ -225,8 +225,8 @@ function test_twodnavierstokes_advection(dt, stepper, dev::Device=CPU(); n=128, 
   tf = 1.0
   nt = round(Int, tf/dt)
 
-  gr = TwoDGrid(dev, n, L)
-  x, y = gridpoints(gr)
+  grid = TwoDGrid(dev, n, L)
+  x, y = gridpoints(grid)
 
    psif = @.   sin(2x)*cos(2y) +  2sin(x)*cos(3y)
   zetaf = @. -8sin(2x)*cos(2y) - 20sin(x)*cos(3y)
@@ -257,10 +257,11 @@ end
 function test_twodnavierstokes_energyenstrophy(dev::Device=CPU())
   nx, Lx  = 128, 2π
   ny, Ly  = 128, 3π
-  gr = TwoDGrid(dev, nx, Lx, ny, Ly)
-  x, y = gridpoints(gr)
+  
+  grid = TwoDGrid(dev, nx, Lx, ny, Ly)
+  x, y = gridpoints(grid)
 
-  k₀, l₀ = 2π/gr.Lx, 2π/gr.Ly # fundamental wavenumbers
+  k₀, l₀ = 2π/grid.Lx, 2π/grid.Ly # fundamental wavenumbers
    ψ₀ = @. sin(2k₀*x)*cos(2l₀*y) + 2sin(k₀*x)*cos(3l₀*y)
    ζ₀ = @. -((2k₀)^2+(2l₀)^2)*sin(2k₀*x)*cos(2l₀*y) - (k₀^2+(3l₀)^2)*2sin(k₀*x)*cos(3l₀*y)
 

--- a/test/test_twodnavierstokes.jl
+++ b/test/test_twodnavierstokes.jl
@@ -34,9 +34,9 @@ function test_twodnavierstokes_stochasticforcing_energybudget(dev::Device=CPU();
 
   forcingcovariancespectrum = ArrayType(dev)(zero(gr.Krsq))
   @. forcingcovariancespectrum = exp(-(sqrt(gr.Krsq) - kf)^2 / (2 * dkf^2))
-  CUDA.@allowscalar @. forcingcovariancespectrum[gr.Krsq .< 2^2] = 0
-  CUDA.@allowscalar @. forcingcovariancespectrum[gr.Krsq .> 20^2] = 0
-  CUDA.@allowscalar @. forcingcovariancespectrum[Kr .< 2π/L] = 0
+  @. forcingcovariancespectrum = ifelse(gr.Krsq < 2^2, 0, forcingcovariancespectrum)
+  @. forcingcovariancespectrum = ifelse(gr.Krsq > 20^2, 0, forcingcovariancespectrum)
+  @. forcingcovariancespectrum = ifelse(Kr < 2π/L, 0, forcingcovariancespectrum)
   ε0 = parsevalsum(forcingcovariancespectrum .* gr.invKrsq / 2, gr) / (gr.Lx * gr.Ly)
   forcingcovariancespectrum .= ε / ε0 * forcingcovariancespectrum
 
@@ -88,9 +88,9 @@ function test_twodnavierstokes_stochasticforcing_enstrophybudget(dev::Device=CPU
 
   forcingcovariancespectrum = ArrayType(dev)(zero(gr.Krsq))
   @. forcingcovariancespectrum = exp(-(sqrt(gr.Krsq) - kf)^2 / (2 * dkf^2))
-  CUDA.@allowscalar @. forcingcovariancespectrum[gr.Krsq .< 2^2] = 0
-  CUDA.@allowscalar @. forcingcovariancespectrum[gr.Krsq .> 20^2] = 0
-  CUDA.@allowscalar @. forcingcovariancespectrum[Kr .< 2π/L] = 0
+  @. forcingcovariancespectrum = ifelse(gr.Krsq < 2^2, 0, forcingcovariancespectrum)
+  @. forcingcovariancespectrum = ifelse(gr.Krsq > 20^2, 0, forcingcovariancespectrum)
+  @. forcingcovariancespectrum = ifelse(Kr < 2π/L, 0, forcingcovariancespectrum)
   εᶻ0 = parsevalsum(forcingcovariancespectrum / 2, gr) / (gr.Lx * gr.Ly)
   forcingcovariancespectrum .= εᶻ / εᶻ0 * forcingcovariancespectrum
   


### PR DESCRIPTION
This PR closes #141 and other issues related to that (e.g., those related with constructing `forcingspetrumcovariance`).

This PR was made possible with the patience of @vchuravy on slack; thanks!

Also closes #121 and closes #130.