### PR TITLE
Clearer syntax/function arguments + better docs for MultilayerQG

### DIFF
--- a/docs/src/modules/multilayerqg.md
+++ b/docs/src/modules/multilayerqg.md
@@ -53,7 +53,7 @@ where
 Including an imposed zonal flow ``U_j(y)`` in each layer, the equations of motion are:
 
 ```math
-\partial_t q_j + \mathsf{J}(\psi_j, q_j ) + (U_j - \partial_y\psi_j) \partial_x Q_j +  U_j \partial_x q_j  + (\partial_y Q_j)(\partial_x \psi_j) = -\delta_{j,n} \mu \nabla^2 \psi_n - \nu(-1)^{n_\nu} \nabla^{2n_\nu} q_j,
+\partial_t q_j + \mathsf{J}(\psi_j, q_j ) + (U_j - \partial_y\psi_j) \partial_x Q_j +  U_j \partial_x q_j  + (\partial_y Q_j)(\partial_x \psi_j) = -\delta_{j, n} \mu \nabla^2 \psi_n - \nu (-1)^{n_\nu} \nabla^{2n_\nu} q_j,
 ```
 
 with
@@ -63,30 +63,19 @@ with
 \partial_x Q_j \equiv \delta_{j,n} \partial_x \eta \ .
 ```
 
-The eddy kinetic energy in each layer is:
+The eddy kinetic energy in each layer and the eddy potential energy that corresponds to each 
+fluid interface is computed via `energies()`:
 
-```math
-\textrm{KE}_j = \dfrac{H_j}{H} \int \dfrac1{2} |\boldsymbol{\nabla} \psi_j|^2 \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y} \ , \quad j = 1, \dots, n \ ,
+```@docs
+GeophysicalFlows.MultilayerQG.energies
 ```
 
-while the eddy potential energy related to each of fluid interface is
+The lateral eddy fluxes in each layer and the vertical fluxes across fluid interfaces are
+computed via `fluxes()`:
 
-```math
-\textrm{PE}_{j+1/2} = \int \dfrac1{2} \dfrac{f_0^2}{g'_{j+1/2}} (\psi_j - \psi_{j+1})^2 \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y} \ , \quad j = 1, \dots, n-1 \ .
+```@docs
+GeophysicalFlows.MultilayerQG.fluxes
 ```
-
-The lateral eddy fluxes in each layer are:
-
-```math
-\textrm{lateralfluxes}_j = \dfrac{H_j}{H} \int U_j\,\upsilon_j \,\partial_y u_j \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y} \ , \quad j = 1, \dots, n \ ,
-```
-
-while the vertical fluxes accros fluid interfaces are:
-
-```math
-\textrm{verticalfluxes}_{j+1/2} = \int \dfrac{f_0^2}{g'_{j+1/2} H} (U_j - U_{j+1}) \, \upsilon_{j+1} \, \psi_{j} \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y} \ , \quad j = 1 , \dots , n-1.
-```
-
 
 ### Implementation
 

--- a/docs/src/modules/multilayerqg.md
+++ b/docs/src/modules/multilayerqg.md
@@ -2,35 +2,40 @@
 
 ### Basic Equations
 
-This module solves the layered quasi-geostrophic equations on a beta-plane of variable fluid depth $H-h(x,y)$. The flow in each layer is obtained through a streamfunction $\psi_j$ as $(u_j, \upsilon_j) = (-\partial_y\psi_j, \partial_x\psi_j)$, $j=1,...,n$, where $n$ is the number of fluid layers.
+This module solves the layered quasi-geostrophic equations on a beta-plane of variable fluid 
+depth ``H - h(x, y)``. The flow in each layer is obtained through a streamfunction ``\psi_j`` as 
+``(u_j, \upsilon_j) = (-\partial_y \psi_j, \partial_x \psi_j)``, ``j = 1, \dots, n``, where ``n`` 
+is the number of fluid layers.
 
 The QGPV in each layer is
 
 ```math
-\mathrm{QGPV}_j = q_j  + \underbrace{f_0+\beta y}_{\textrm{planetary PV}} + \delta_{j,n}\underbrace{\frac{f_0 h}{H_n}}_{\textrm{topographic PV}},\quad j=1,...,n.
+\mathrm{QGPV}_j = q_j  + \underbrace{f_0 + \beta y}_{\textrm{planetary PV}} + \delta_{j,n} \underbrace{\frac{f_0 h}{H_n}}_{\textrm{topographic PV}}, \quad j = 1, \dots, n \ .
 ```
 
-where $q_j$ incorporate the relative vorticity in each layer $\nabla^2\psi_j$ and the vortex stretching terms:
+where ``q_j`` incorporates the relative vorticity in each layer ``\nabla^2\psi_j`` and the 
+vortex stretching terms:
 
 ```math
-q_1 = \nabla^2\psi_1 + F_{3/2, 1} (\psi_2-\psi_1),\\
-q_j = \nabla^2\psi_j + F_{j-1/2, j} (\psi_{j-1}-\psi_j) + F_{j+1/2, j} (\psi_{j+1}-\psi_j),\quad j=2,\dots,n-1,\\
-q_n = \nabla^2\psi_n + F_{n-1/2, n} (\psi_{n-1}-\psi_n).
+q_1 = \nabla^2 \psi_1 + F_{3/2, 1} (\psi_2 - \psi_1) \ ,\\
+q_j = \nabla^2 \psi_j + F_{j-1/2, j} (\psi_{j-1} - \psi_j) + F_{j+1/2, j} (\psi_{j+1} - \psi_j),\quad j = 2, \dots, n-1 \ ,\\
+q_n = \nabla^2 \psi_n + F_{n-1/2, n} (\psi_{n-1} - \psi_n) \ .
 ```
 
 with
 
 ```math
-F_{j+1/2, k} = \frac{f_0^2}{g'_{j+1/2} H_k}\quad\text{and}\quad
-g'_{j+1/2} = g\frac{\rho_{j+1}-\rho_j}{\rho_{j+1}} .
+F_{j+1/2, k} = \frac{f_0^2}{g'_{j+1/2} H_k} \quad \text{and} \quad
+g'_{j+1/2} = g \frac{\rho_{j+1} - \rho_j}{\rho_{j+1}} .
 ```
 
-In view of the relationships above, when we convert to Fourier space $q$'s and $\psi$'s are related via the matrix equation
+In view of the relationships above, when we convert to Fourier space ``q``'s and ``\psi``'s are 
+related via the matrix equation
 
 ```math
-\begin{pmatrix} \widehat{q}_{\boldsymbol{k},1}\\\vdots\\\widehat{q}_{\boldsymbol{k},n} \end{pmatrix} =
-\underbrace{\left(-|\boldsymbol{k}|^2\mathbb{1} + \mathbb{F} \right)}_{\equiv \mathbb{S}_{\boldsymbol{k}}}
-\begin{pmatrix} \widehat{\psi}_{\boldsymbol{k},1}\\\vdots\\\widehat{\psi}_{\boldsymbol{k},n} \end{pmatrix}
+\begin{pmatrix} \widehat{q}_{\boldsymbol{k}, 1}\\\vdots\\\widehat{q}_{\boldsymbol{k}, n} \end{pmatrix} =
+\underbrace{\left(-|\boldsymbol{k}|^2 \mathbb{1} + \mathbb{F} \right)}_{\equiv \mathbb{S}_{\boldsymbol{k}}}
+\begin{pmatrix} \widehat{\psi}_{\boldsymbol{k}, 1}\\\vdots\\\widehat{\psi}_{\boldsymbol{k}, n} \end{pmatrix}
 ```
 
 where
@@ -42,75 +47,80 @@ where
  0           &                  \ddots  &   \ddots   & \ddots & \\
  \vdots      &                          &            &        &  0 \\
  0           &       \cdots             &   0   & F_{n-1/2, n} & -F_{n-1/2, n}
-\end{pmatrix}
+\end{pmatrix}\ .
 ```
 
-Including an imposed zonal flow $U_j(y)$ in each layer the equations of motion are:
+Including an imposed zonal flow ``U_j(y)`` in each layer, the equations of motion are:
 
 ```math
-\partial_t q_j + \mathsf{J}(\psi_j, q_j ) + (U_j - \partial_y\psi_j) \partial_x Q_j +  U_j \partial_x q_j  + (\partial_y Q_j)(\partial_x\psi_j) = -\delta_{j,n}\mu\nabla^2\psi_n - \nu(-1)^{n_\nu} \nabla^{2n_\nu} q_j,
+\partial_t q_j + \mathsf{J}(\psi_j, q_j ) + (U_j - \partial_y\psi_j) \partial_x Q_j +  U_j \partial_x q_j  + (\partial_y Q_j)(\partial_x \psi_j) = -\delta_{j,n} \mu \nabla^2 \psi_n - \nu(-1)^{n_\nu} \nabla^{2n_\nu} q_j,
 ```
 
 with
 
 ```math
-\partial_y Q_j \equiv \beta - \partial_y^2 U_j - (1-\delta_{j,1})F_{j-1/2, j} (U_{j-1}-U_j) - (1-\delta_{j,n})F_{j+1/2, j} (U_{j+1}-U_j) + \delta_{j,n}\partial_y\eta, \\
-\partial_x Q_j \equiv \delta_{j,n}\partial_x\eta.
+\partial_y Q_j \equiv \beta - \partial_y^2 U_j - (1-\delta_{j,1}) F_{j-1/2, j} (U_{j-1} - U_j) - (1 - \delta_{j,n}) F_{j+1/2, j} (U_{j+1} - U_j) + \delta_{j,n} \partial_y \eta \ , \\
+\partial_x Q_j \equiv \delta_{j,n} \partial_x \eta \ .
 ```
 
 The eddy kinetic energy in each layer is:
 
 ```math
-\textrm{KE}_j = \dfrac{H_j}{H} \int \dfrac1{2} |\boldsymbol{\nabla}\psi_j|^2 \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y},\quad j=1,\dots,n,
+\textrm{KE}_j = \dfrac{H_j}{H} \int \dfrac1{2} |\boldsymbol{\nabla} \psi_j|^2 \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y} \ , \quad j = 1, \dots, n \ ,
 ```
 
 while the eddy potential energy related to each of fluid interface is
 
 ```math
-\textrm{PE}_{j+1/2} = \int \dfrac1{2} \dfrac{f_0^2}{g'_{j+1/2}} (\psi_j-\psi_{j+1})^2 \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y},\quad j=1,\dots,n-1.
+\textrm{PE}_{j+1/2} = \int \dfrac1{2} \dfrac{f_0^2}{g'_{j+1/2}} (\psi_j - \psi_{j+1})^2 \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y} \ , \quad j = 1, \dots, n-1 \ .
 ```
 
 The lateral eddy fluxes in each layer are:
 
 ```math
-\textrm{lateralfluxes}_j = \dfrac{H_j}{H} \int U_j\,\upsilon_j \,\partial_y u_j \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y},\quad j=1,\dots,n,
+\textrm{lateralfluxes}_j = \dfrac{H_j}{H} \int U_j\,\upsilon_j \,\partial_y u_j \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y} \ , \quad j = 1, \dots, n \ ,
 ```
 
 while the vertical fluxes accros fluid interfaces are:
 
 ```math
-\textrm{verticalfluxes}_{j+1/2} = \int \dfrac{f_0^2}{g'_{j+1/2} H} (U_j-U_{j+1})\,\upsilon_{j+1}\,\psi_{j} \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y},\quad j=1,\dots,n-1.
-
+\textrm{verticalfluxes}_{j+1/2} = \int \dfrac{f_0^2}{g'_{j+1/2} H} (U_j - U_{j+1}) \, \upsilon_{j+1} \, \psi_{j} \frac{\mathrm{d}^2\boldsymbol{x}}{L_x L_y} \ , \quad j = 1 , \dots , n-1.
 ```
 
 
 ### Implementation
 
-Matrices $\mathbb{S}_{\boldsymbol{k}}$ as well as $\mathbb{S}^{-1}_{\boldsymbol{k}}$ are included in `params` as `params.S` and `params.invS` respectively. Additionally, 
-the background PV gradients $\partial_x Q$ and $\partial_y Q$ are also included in the `params` as `params.Qx` and `params.Qy`.
+Matrices ``\mathbb{S}_{\boldsymbol{k}}`` as well as ``\mathbb{S}^{-1}_{\boldsymbol{k}}`` are included 
+in `params` as `params.S` and `params.S⁻¹` respectively. Additionally, the background PV gradients 
+``\partial_x Q`` and ``\partial_y Q`` are also included in the `params` as `params.Qx` and `params.Qy`.
 
-You can get $\widehat{\psi}_j$ from $\widehat{q}_j$ with `streamfunctionfrompv!(psih, qh, params, grid)`, while to get $\widehat{q}_j$ from $\widehat{\psi}_j$ you need to call `pvfromstreamfunction!(qh, psih, params, grid)`.
+You can get ``\widehat{\psi}_j`` from ``\widehat{q}_j`` with `streamfunctionfrompv!(psih, qh, params, grid)`, 
+while to get ``\widehat{q}_j`` from ``\widehat{\psi}_j`` you need to call `pvfromstreamfunction!(qh, psih, params, grid)`.
 
 
 The equations of motion are time-stepped forward in Fourier space:
 
 ```math
 \partial_t \widehat{q}_j = - \widehat{\mathsf{J}(\psi_j, q_j)}  - \widehat{U_j \partial_x Q_j} - \widehat{U_j \partial_x q_j}
-+ \widehat{(\partial_y\psi_j) \partial_x Q_j}  - \widehat{(\partial_x\psi_j)(\partial_y Q_j)} + \delta_{j,n}\mu k^{2} \widehat{\psi}_n - \nu k^{2n_\nu} \widehat{q}_j
++ \widehat{(\partial_y \psi_j) \partial_x Q_j}  - \widehat{(\partial_x\psi_j)(\partial_y Q_j)} + \delta_{j,n} \mu k^{2} \widehat{\psi}_n - \nu k^{2n_\nu} \widehat{q}_j \ .
 ```
 
-In doing so the Jacobian is computed in the conservative form: $\mathsf{J}(f,g) =
-\partial_y [ (\partial_x f) g] -\partial_x[ (\partial_y f) g]$.
+In doing so the Jacobian is computed in the conservative form: ``\mathsf{J}(f,g) =
+\partial_y [ (\partial_x f) g] -\partial_x[ (\partial_y f) g]``.
 
-Equations are formulated using $q_j$ as the state variables, i.e., `sol=qh`.
+Equations are formulated using $q_j$ as the state variables, i.e., `sol = qh`.
 
 Thus:
 
-$$\mathcal{L} = - \nu k^{2n_\nu}\ ,$$
-$$\mathcal{N}(\widehat{q}_j) = - \widehat{\mathsf{J}(\psi_j, q_j)} - \widehat{U_j \partial_x Q_j} - \widehat{U_j \partial_x q_j}
- + \widehat{(\partial_y\psi_j)(\partial_x Q_j)} - \widehat{(\partial_x\psi_j)(\partial_y Q_j)} + \delta_{j,n}\mu k^{2} \widehat{\psi}_n\ .$$
-
+```math
+\begin{aligned}
+\mathcal{L} & = - \nu k^{2n_\nu} \ , \\
+\mathcal{N}(\widehat{q}_j) & = - \widehat{\mathsf{J}(\psi_j, q_j)} - \widehat{U_j \partial_x Q_j} - \widehat{U_j \partial_x q_j}
+ + \widehat{(\partial_y \psi_j)(\partial_x Q_j)} - \widehat{(\partial_x \psi_j)(\partial_y Q_j)} + \delta_{j,n} \mu k^{2} \widehat{\psi}_n\ .
+\end{aligned}
+```
+ 
 
  ## Examples
 
- - `examples/multilayerqg_2layer.jl`: A script that simulates baroclinic eddy turbulence growth and equilibration of the Phillips 2-layer model.
+ - `examples/multilayerqg_2layer.jl`: A script that simulates the growth and equilibration of baroclinic eddy turbulence in the Phillips 2-layer model.

--- a/docs/src/modules/multilayerqg.md
+++ b/docs/src/modules/multilayerqg.md
@@ -18,7 +18,7 @@ vortex stretching terms:
 
 ```math
 q_1 = \nabla^2 \psi_1 + F_{3/2, 1} (\psi_2 - \psi_1) \ ,\\
-q_j = \nabla^2 \psi_j + F_{j-1/2, j} (\psi_{j-1} - \psi_j) + F_{j+1/2, j} (\psi_{j+1} - \psi_j),\quad j = 2, \dots, n-1 \ ,\\
+q_j = \nabla^2 \psi_j + F_{j-1/2, j} (\psi_{j-1} - \psi_j) + F_{j+1/2, j} (\psi_{j+1} - \psi_j) \ , \quad j = 2, \dots, n-1 \ ,\\
 q_n = \nabla^2 \psi_n + F_{n-1/2, n} (\psi_{n-1} - \psi_n) \ .
 ```
 

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -552,14 +552,21 @@ set_ψ!(prob, ψ) = set_ψ!(prob.sol, prob.params, prob.vars, prob.grid, ψ)
 
 
 """
+    energies(vars, params, grid, sol)
     energies(prob)
 
-Returns the kinetic energy of each fluid layer ``KE_1, ..., KE_{nlayers}``, and the
-potential energy of each fluid interface ``PE_{3/2}, ..., PE_{nlayers-1/2}``.
-(When `nlayers=1` only kinetic energy is returned.)
+Returns the kinetic energy of each fluid layer KE``_1, ...,`` KE``_{n}``, and the
+potential energy of each fluid interface PE``_{3/2}, ...,`` PE``_{n-1/2}``, where ``n``
+is the number of layers in the fluid. (When ``n=1``, only the kinetic energy is returned.)
 
-The kinetic energy at the ``j``-th fluid layer is ``KE_{j} = H_j / H ∫ ½ |𝛁ψ_{j}|² d²𝐱 / Lx Ly`` and
-the potential energy at the ``j+1/2`` fluid interface is ``PE_{j+1/2} = ∫ ½ f₀²/g'_{j+1/2} (ψ_j - ψ_{j+1})^2 d²𝐱 / Lx Ly``.
+The kinetic energy at the ``j``-th fluid layer is 
+```math
+\\textrm{KE}_j = \\frac{H_j}{H} \\int \\frac1{2} |\\boldsymbol{\\nabla} \\psi_j|^2 \\frac{\\mathrm{d}^2 \\boldsymbol{x}}{L_x L_y} \\ , \\quad j = 1, \\dots, n \\ ,
+```
+while the potential energy that corresponds to the interface ``j+1/2`` (i.e., interface between the ``j``-th and ``(j+1)``-th fluid layer) is
+```math
+\\textrm{PE}_{j+1/2} = \\int \\frac1{2} \\frac{f_0^2}{g'_{j+1/2}} (\\psi_j - \\psi_{j+1})^2 \\frac{\\mathrm{d}^2 \\boldsymbol{x}}{L_x L_y} \\ , \\quad j = 1, \\dots, n-1 \\ .
+```
 """
 function energies(vars, params, grid, sol)
   nlayers = numberoflayers(params)
@@ -595,12 +602,26 @@ end
 energies(prob) = energies(prob.vars, prob.params, prob.grid, prob.sol)
 
 """
+    fluxes(vars, params, grid, sol)
     fluxes(prob)
 
-Returns the lateral eddy fluxes within each fluid layer
-lateralfluxes_1, ..., lateralfluxes_nlayers and also the vertical eddy fluxes for
-each fluid interface verticalfluxes_{3/2}, ..., verticalfluxes_{nlayers-1/2}.
-(When `nlayers=1` only the lateral fluxes are returned.)
+Returns the lateral eddy fluxes within each fluid layer, lateralfluxes``_1,...,``lateralfluxes``_n``
+and also the vertical eddy fluxes at each fluid interface 
+verticalfluxes``_{3/2}``, ...,`` verticalfluxes``_{n-1/2}, where ``n`` is the number of layers in the fluid.
+(When ``n=1``, only the lateral fluxes are returned.)
+
+The lateral eddy fluxes whithin the ``j``-th fluid layer are
+```math
+\\textrm{lateralfluxes}_j = \\frac{H_j}{H} \\int U_j \\, \\upsilon_j \\, \\partial_y u_j 
+\\frac{\\mathrm{d}^2 \\boldsymbol{x}}{L_x L_y} \\ , \\quad j = 1, \\dots, n \\ ,
+```
+while the vertical eddy fluxes at the ``j+1/2``-th fluid interface  (i.e., interface between 
+the ``j``-th and ``(j+1)``-th fluid layer) are
+```math
+\\textrm{verticalfluxes}_{j+1/2} = \\int \\frac{f_0^2}{g'_{j+1/2} H} (U_j - U_{j+1}) \\, 
+\\upsilon_{j+1} \\, \\psi_{j} \\frac{\\mathrm{d}^2 \\boldsymbol{x}}{L_x L_y} \\ , \\quad 
+j = 1 , \\dots , n-1.
+```
 """
 function fluxes(vars, params, grid, sol)
   nlayers = numberoflayers(params)

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -554,9 +554,12 @@ set_ψ!(prob, ψ) = set_ψ!(prob.sol, prob.params, prob.vars, prob.grid, ψ)
 """
     energies(prob)
 
-Returns the kinetic energy of each fluid layer KE_1, ..., KE_nlayers, and the
-potential energy of each fluid interface PE_{3/2}, ..., PE_{nlayers-1/2}.
+Returns the kinetic energy of each fluid layer ``KE_1, ..., KE_{nlayers}``, and the
+potential energy of each fluid interface ``PE_{3/2}, ..., PE_{nlayers-1/2}``.
 (When `nlayers=1` only kinetic energy is returned.)
+
+The kinetic energy at the ``j``-th fluid layer is ``KE_{j} = H_j / H ∫ ½ |𝛁ψ_{j}|² d²𝐱 / Lx Ly`` and
+the potential energy at the ``j+1/2`` fluid interface is ``PE_{j+1/2} = ∫ ½ f₀²/g'_{j+1/2} (ψ_j - ψ_{j+1})^2 d²𝐱 / Lx Ly``.
 """
 function energies(vars, params, grid, sol)
   nlayers = numberoflayers(params)
@@ -565,7 +568,7 @@ function energies(vars, params, grid, sol)
   @. vars.qh = sol
   streamfunctionfrompv!(vars.ψh, vars.qh, params, grid)
   
-  abs²∇𝐮h = vars.uh # use vars.uh as scratch variable
+  abs²∇𝐮h = vars.uh        # use vars.uh as scratch variable
   @. abs²∇𝐮h = grid.Krsq * abs2(vars.ψh)
   
   for j = 1:nlayers
@@ -583,7 +586,7 @@ function energies(vars, params::SingleLayerParams, grid, sol)
   @. vars.qh = sol
   streamfunctionfrompv!(vars.ψh, vars.qh, params, grid)
 
-  abs²∇𝐮h = vars.uh # use vars.uh as scratch variable
+  abs²∇𝐮h = vars.uh        # use vars.uh as scratch variable
   @. abs²∇𝐮h = grid.Krsq * abs2(vars.ψh)
   
   return 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h, grid)
@@ -606,8 +609,8 @@ function fluxes(vars, params, grid, sol)
 
   updatevars!(vars, params, grid, sol)
 
-  ∂u∂yh = vars.uh # use vars.uh as scratch variable
-  ∂u∂y  = vars.u  # use vars.u as scratch variable
+  ∂u∂yh = vars.uh           # use vars.uh as scratch variable
+  ∂u∂y  = vars.u            # use vars.u  as scratch variable
 
   @. ∂u∂yh = im * grid.l * vars.uh
   invtransform!(∂u∂y, ∂u∂yh, params)
@@ -626,8 +629,8 @@ end
 function fluxes(vars, params::SingleLayerParams, grid, sol)
   updatevars!(vars, params, grid, sol)
 
-  ∂u∂yh = vars.uh # use vars.uh as scratch variable
-  ∂u∂y  = vars.u  # use vars.u as scratch variable
+  ∂u∂yh = vars.uh           # use vars.uh as scratch variable
+  ∂u∂y  = vars.u            # use vars.u  as scratch variable
 
   @. ∂u∂yh = im * grid.l * vars.uh
   invtransform!(∂u∂y, ∂u∂yh, params)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,7 +107,7 @@ for dev in devices
     @test test_sqg_noforcing(dev)
     @test SurfaceQG.nothingfunction() == nothing
   end
-    
+  
   @testset "MultilayerQG" begin
     include("test_multilayerqg.jl")
     


### PR DESCRIPTION
The PR accommodates the convention that functions with names ending with ! modify their first argument. Therefore, e.g., `set_q!` now includes `sol` as its first argument, while `updatevars!` has `vars` as its first argument.

Furthermore, this PR improves code readability and docs.

https://fourierflows.github.io/GeophysicalFlowsDocumentation/previews/PR155/