### PR TITLE
MultilayerQG -> MultiLayerQG

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ All modules provide solvers on two-dimensional domains. We currently provide
 * `TwoDNavierStokes`: the two-dimensional vorticity equation.
 * `SingleLayerQG`: the barotropic or equivalent-barotropic quasi-geostrophic equation, which generalizes `TwoDNavierStokes` to cases with topography, Coriolis parameters of the form `f = f₀ + βy`, and finite Rossby radius of deformation.
 * `BarotropicQGQL`: the quasi-linear barotropic quasi-geostrophic equation.
-* `MultilayerQG`: a multi-layer quasi-geostrophic model over topography and with the ability to impose a zonal flow `U_n(y)` in each layer.
+* `MultiLayerQG`: a multi-layer quasi-geostrophic model over topography and with the ability to impose a zonal flow `U_n(y)` in each layer.
 * `SurfaceQG`: a surface quasi-geostrophic model.
 
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -80,7 +80,7 @@ sitename = "GeophysicalFlows.jl",
               "BarotropicQGQL" => Any[
                 "generated/barotropicqgql_betaforced.md",
                 ],
-              "MultilayerQG" => Any[
+              "MultiLayerQG" => Any[
                 "generated/multilayerqg_2layer.md"
                 ],
               "SurfaceQG" => Any[

--- a/docs/src/man/functions.md
+++ b/docs/src/man/functions.md
@@ -33,10 +33,10 @@ Private = false
 Order = [:function]
 ```
 
-## Functions exported from `MultilayerQG`:
+## Functions exported from `MultiLayerQG`:
 
 ```@autodocs
-Modules = [GeophysicalFlows.MultilayerQG]
+Modules = [GeophysicalFlows.MultiLayerQG]
 Private = false
 Order = [:function]
 ```

--- a/docs/src/man/types.md
+++ b/docs/src/man/types.md
@@ -32,10 +32,10 @@ Public = false
 Order = [:type]
 ```
 
-## Private types in module `MultilayerQG`:
+## Private types in module `MultiLayerQG`:
 
 ```@autodocs
-Modules = [GeophysicalFlows.MultilayerQG]
+Modules = [GeophysicalFlows.MultiLayerQG]
 Public = false
 Order = [:type]
 ```

--- a/docs/src/modules/multilayerqg.md
+++ b/docs/src/modules/multilayerqg.md
@@ -1,4 +1,4 @@
-# MultilayerQG Module
+# MultiLayerQG Module
 
 ### Basic Equations
 
@@ -67,14 +67,14 @@ The eddy kinetic energy in each layer and the eddy potential energy that corresp
 fluid interface is computed via `energies()`:
 
 ```@docs
-GeophysicalFlows.MultilayerQG.energies
+GeophysicalFlows.MultiLayerQG.energies
 ```
 
 The lateral eddy fluxes in each layer and the vertical fluxes across fluid interfaces are
 computed via `fluxes()`:
 
 ```@docs
-GeophysicalFlows.MultilayerQG.fluxes
+GeophysicalFlows.MultiLayerQG.fluxes
 ```
 
 ### Implementation

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -11,8 +11,8 @@ using FourierFlows, Plots, Printf
 
 using FFTW: rfft, irfft
 using Random: seed!
-import GeophysicalFlows.MultilayerQG
-import GeophysicalFlows.MultilayerQG: energies
+import GeophysicalFlows.MultiLayerQG
+import GeophysicalFlows.MultiLayerQG: energies
 
 
 # ## Choosing a device: CPU or GPU
@@ -49,7 +49,7 @@ nothing # hide
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments,
-prob = MultilayerQG.Problem(nlayers, dev; nx=n, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ, U=U, dt=dt, stepper=stepper, μ=μ, β=β)
+prob = MultiLayerQG.Problem(nlayers, dev; nx=n, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ, U=U, dt=dt, stepper=stepper, μ=μ, β=β)
 nothing # hide
 
 # and define some shortcuts.
@@ -68,7 +68,7 @@ q_i  = 4e-3randn((grid.nx, grid.ny, nlayers))
 qh_i = prob.timestepper.filter .* rfft(q_i, (1, 2)) # only apply rfft in dims=1, 2
 q_i  = irfft(qh_i, grid.nx, (1, 2)) # only apply irfft in dims=1, 2
 
-MultilayerQG.set_q!(prob, q_i)
+MultiLayerQG.set_q!(prob, q_i)
 nothing # hide
 
 
@@ -209,7 +209,7 @@ anim = @animate for j = 0:round(Int, nsteps / nsubs)
   push!(p[6][1], μ * E.t[E.i], E.data[E.i][2][1])
   
   stepforward!(prob, diags, nsubs)
-  MultilayerQG.updatevars!(prob)
+  MultiLayerQG.updatevars!(prob)
 end
 
 gif(anim, "multilayerqg_2layer.gif", fps=18)

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -1,4 +1,4 @@
-module MultilayerQG
+module MultiLayerQG
 
 export
   fwdtransform!,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ import # use 'import' rather than 'using' for submodules to keep namespace clean
   GeophysicalFlows.TwoDNavierStokes,
   GeophysicalFlows.SingleLayerQG,
   GeophysicalFlows.BarotropicQGQL,
-  GeophysicalFlows.MultilayerQG,
+  GeophysicalFlows.MultiLayerQG,
   GeophysicalFlows.SurfaceQG
 
 using FourierFlows: parsevalsum
@@ -118,7 +118,7 @@ for dev in devices
     @test SurfaceQG.nothingfunction() == nothing
   end
   
-  @testset "MultilayerQG" begin
+  @testset "MultiLayerQG" begin
     include("test_multilayerqg.jl")
     
     @test test_pvtofromstreamfunction_2layer(dev)
@@ -134,7 +134,7 @@ for dev in devices
     @test test_mqg_paramsconstructor(dev)
     @test test_mqg_stochasticforcedproblemconstructor(dev)
     @test test_mqg_problemtype(dev, Float32)
-    @test MultilayerQG.nothingfunction() == nothing
+    @test MultiLayerQG.nothingfunction() == nothing
   end
 end
 end # time

--- a/test/test_multilayerqg.jl
+++ b/test/test_multilayerqg.jl
@@ -80,7 +80,7 @@ function test_pvtofromstreamfunction_2layer(dev::Device=CPU())
   H = [0.2, 0.8]   # q1 = Δψ1 + 25*(ψ2-ψ1), and
   ρ = [4.0, 5.0]   # q2 = Δψ2 + 25/4*(ψ1-ψ2).
 
-  prob = MultilayerQG.Problem(nlayers, dev; nx=n, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ)
+  prob = MultiLayerQG.Problem(nlayers, dev; nx=n, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ)
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   ψ1, ψ2, q1, q2, ψ1x, ψ2x, q1x, q2x, Δψ2, Δq1, Δq2 = constructtestfields_2layer(gr)
@@ -88,14 +88,14 @@ function test_pvtofromstreamfunction_2layer(dev::Device=CPU())
   vs.ψh[:, :, 1] .= rfft(ψ1)
   vs.ψh[:, :, 2] .= rfft(ψ2)
 
-  MultilayerQG.pvfromstreamfunction!(vs.qh, vs.ψh, pr, gr)
-  MultilayerQG.invtransform!(vs.q, vs.qh, pr)
+  MultiLayerQG.pvfromstreamfunction!(vs.qh, vs.ψh, pr, gr)
+  MultiLayerQG.invtransform!(vs.q, vs.qh, pr)
 
   vs.qh[:, :, 1] .= rfft(q1)
   vs.qh[:, :, 2] .= rfft(q2)
 
-  MultilayerQG.streamfunctionfrompv!(vs.ψh, vs.qh, pr, gr)
-  MultilayerQG.invtransform!(vs.ψ, vs.ψh, pr)
+  MultiLayerQG.streamfunctionfrompv!(vs.ψh, vs.qh, pr, gr)
+  MultiLayerQG.invtransform!(vs.ψ, vs.ψh, pr)
 
   return isapprox(q1, vs.q[:, :, 1], rtol=rtol_multilayerqg) && isapprox(q2, vs.q[:, :, 2], rtol=rtol_multilayerqg) && isapprox(ψ1, vs.ψ[:, :, 1], rtol=rtol_multilayerqg) && isapprox(ψ2, vs.ψ[:, :, 2], rtol=rtol_multilayerqg)
 end
@@ -121,7 +121,7 @@ function test_pvtofromstreamfunction_3layer(dev::Device=CPU())
   ρ = [4.0, 5.0, 6.0]    # q2 = Δψ2 + 20ψ1 - 44ψ2 + 24ψ3,
                          # q3 = Δψ3        + 12ψ2 - 12ψ3.
 
-  prob = MultilayerQG.Problem(nlayers, dev; nx=n, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ)
+  prob = MultiLayerQG.Problem(nlayers, dev; nx=n, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ)
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   ψ1, ψ2, ψ3, q1, q2, q3 = constructtestfields_3layer(gr)
@@ -130,15 +130,15 @@ function test_pvtofromstreamfunction_3layer(dev::Device=CPU())
   vs.ψh[:, :, 2] .= rfft(ψ2)
   vs.ψh[:, :, 3] .= rfft(ψ3)
 
-  MultilayerQG.pvfromstreamfunction!(vs.qh, vs.ψh, pr, gr)
-  MultilayerQG.invtransform!(vs.q, vs.qh, pr)
+  MultiLayerQG.pvfromstreamfunction!(vs.qh, vs.ψh, pr, gr)
+  MultiLayerQG.invtransform!(vs.q, vs.qh, pr)
 
   vs.qh[:, :, 1] .= rfft(q1)
   vs.qh[:, :, 2] .= rfft(q2)
   vs.qh[:, :, 3] .= rfft(q3)
 
-  MultilayerQG.streamfunctionfrompv!(vs.ψh, vs.qh, pr, gr)
-  MultilayerQG.invtransform!(vs.ψ, vs.ψh, pr)
+  MultiLayerQG.streamfunctionfrompv!(vs.ψh, vs.qh, pr, gr)
+  MultiLayerQG.invtransform!(vs.ψ, vs.ψh, pr)
 
   return isapprox(q1, vs.q[:, :, 1], rtol=rtol_multilayerqg) && isapprox(q2, vs.q[:, :, 2], rtol=rtol_multilayerqg) && isapprox(q3, vs.q[:, :, 3], rtol=rtol_multilayerqg) && isapprox(ψ1, vs.ψ[:, :, 1], rtol=rtol_multilayerqg) && isapprox(ψ2, vs.ψ[:, :, 2], rtol=rtol_multilayerqg) && isapprox(ψ3, vs.ψ[:, :, 3], rtol=rtol_multilayerqg)
 end
@@ -211,7 +211,7 @@ function test_mqg_nonlinearadvection(dt, stepper, dev::Device=CPU(); n=128, L=2�
     nothing
   end
 
-  prob = MultilayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=Lx, Ly=Ly,
+  prob = MultiLayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=Lx, Ly=Ly,
    f₀=f₀, g=g, H=H, ρ=ρ, U=U, eta=η, β=β, μ=μ, ν=ν, nν=nν, calcFq=calcFq!, stepper=stepper, dt=dt)
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
@@ -223,10 +223,10 @@ function test_mqg_nonlinearadvection(dt, stepper, dev::Device=CPU(); n=128, L=2�
   @views ψf[:, :, 1] = ψ1
   @views ψf[:, :, 2] = ψ2
 
-  MultilayerQG.set_q!(prob, qf)
+  MultiLayerQG.set_q!(prob, qf)
   
   stepforward!(prob, nt)
-  MultilayerQG.updatevars!(prob)
+  MultiLayerQG.updatevars!(prob)
   
   return isapprox(vs.q, qf, rtol=rtol_multilayerqg) && isapprox(vs.ψ, ψf, rtol=rtol_multilayerqg)		
 end
@@ -299,7 +299,7 @@ function test_mqg_linearadvection(dt, stepper, dev::Device=CPU(); n=128, L=2π, 
     nothing
   end
 
-  prob = MultilayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=Lx, Ly=Ly, f₀=f₀, g=g, H=H, ρ=ρ, U=U, eta=η, β=β, μ=μ, ν=ν, nν=nν, calcFq=calcFq!, stepper=stepper, dt=dt, linear=true)
+  prob = MultiLayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=Lx, Ly=Ly, f₀=f₀, g=g, H=H, ρ=ρ, U=U, eta=η, β=β, μ=μ, ν=ν, nν=nν, calcFq=calcFq!, stepper=stepper, dt=dt, linear=true)
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   qf = zeros(dev, T, (gr.nx, gr.ny, nlayers))
@@ -310,10 +310,10 @@ function test_mqg_linearadvection(dt, stepper, dev::Device=CPU(); n=128, L=2π, 
   @views ψf[:, :, 1] = ψ1
   @views ψf[:, :, 2] = ψ2
 
-  MultilayerQG.set_q!(prob, qf)
+  MultiLayerQG.set_q!(prob, qf)
 
   stepforward!(prob, nt)
-  MultilayerQG.updatevars!(prob)
+  MultiLayerQG.updatevars!(prob)
 
   return isapprox(vs.q, qf, rtol=rtol_multilayerqg) && isapprox(vs.ψ, ψf, rtol=rtol_multilayerqg)
 end
@@ -337,7 +337,7 @@ function test_mqg_energies(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler", 
   H = [0.2, 0.8]    # q1 = Δψ1 + 25*(ψ2-ψ1), and
   ρ = [4.0, 5.0]    # q2 = Δψ2 + 25/4*(ψ1-ψ2).
 
-  prob = MultilayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=Lx, Ly=Ly, f₀=f₀, g=g, H=H, ρ=ρ)
+  prob = MultiLayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=Lx, Ly=Ly, f₀=f₀, g=g, H=H, ρ=ρ)
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   ψ1, ψ2, q1, q2, ψ1x, ψ2x, q1x, q2x, Δψ2, Δq1, Δq2 = constructtestfields_2layer(gr)
@@ -346,11 +346,11 @@ function test_mqg_energies(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler", 
   CUDA.@allowscalar @views qf[:, :, 1] .= q1
   CUDA.@allowscalar @views qf[:, :, 2] .= q2
 
-  MultilayerQG.set_q!(prob, qf)
+  MultiLayerQG.set_q!(prob, qf)
 
-  KE, PE = MultilayerQG.energies(prob)
+  KE, PE = MultiLayerQG.energies(prob)
 
-  return isapprox(KE[1], 61/640*1e-6, rtol=rtol_multilayerqg) && isapprox(KE[2], 3*1e-6, rtol=rtol_multilayerqg) && isapprox(PE[1], 1025/1152*1e-6, rtol=rtol_multilayerqg) && MultilayerQG.addforcing!(prob.timestepper.RHS₁, sol, cl.t, cl, vs, pr, gr)==nothing
+  return isapprox(KE[1], 61/640*1e-6, rtol=rtol_multilayerqg) && isapprox(KE[2], 3*1e-6, rtol=rtol_multilayerqg) && isapprox(PE[1], 1025/1152*1e-6, rtol=rtol_multilayerqg) && MultiLayerQG.addforcing!(prob.timestepper.RHS₁, sol, cl.t, cl, vs, pr, gr)==nothing
 end
 
 function test_mqg_energysinglelayer(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler", nlayers=1, μ=0.0, ν=0.0, nν=1)
@@ -366,11 +366,11 @@ function test_mqg_energysinglelayer(dev::Device=CPU(); dt=0.001, stepper="Forwar
   ψ0 = @. sin(2k₀*x)*cos(2l₀*y) + 2sin(k₀*x)*cos(3l₀*y)
   q0 = @. -((2k₀)^2+(2l₀)^2)*sin(2k₀*x)*cos(2l₀*y) - (k₀^2+(3l₀)^2)*2sin(k₀*x)*cos(3l₀*y)
 
-  prob = MultilayerQG.Problem(nlayers, dev; nx=nx, Lx=Lx, ny=ny, Ly=Ly, stepper=stepper, U=zeros(ny))
+  prob = MultiLayerQG.Problem(nlayers, dev; nx=nx, Lx=Lx, ny=ny, Ly=Ly, stepper=stepper, U=zeros(ny))
 
-  MultilayerQG.set_q!(prob, reshape(q0, (nx, ny, nlayers)))
+  MultiLayerQG.set_q!(prob, reshape(q0, (nx, ny, nlayers)))
 
-  energyq0 = MultilayerQG.energies(prob)
+  energyq0 = MultiLayerQG.energies(prob)
 
   return isapprox(energyq0, energy_calc, rtol=rtol_multilayerqg)
 end
@@ -396,7 +396,7 @@ function test_mqg_fluxes(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler", n=
   U = zeros(ny, nlayers)
   U[:, 1] = @. sech(gr.y / 0.2)^2
 
-  prob = MultilayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=Lx, Ly=Ly, f₀=f₀, g=g, H=H, ρ=ρ, U=U)
+  prob = MultiLayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=Lx, Ly=Ly, f₀=f₀, g=g, H=H, ρ=ρ, U=U)
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   ψ1 = @. cos(k₀*x) * cos(l₀*y) + sin(k₀*x)
@@ -404,8 +404,8 @@ function test_mqg_fluxes(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler", n=
   ψ = zeros(gr.nx, gr.ny, nlayers)
   CUDA.@allowscalar @views ψ[:, :, 1] .= ψ1
   CUDA.@allowscalar @views ψ[:, :, 2] .= ψ2
-  MultilayerQG.set_ψ!(prob, ψ)
-  lateralfluxes, verticalfluxes = MultilayerQG.fluxes(prob)
+  MultiLayerQG.set_ψ!(prob, ψ)
+  lateralfluxes, verticalfluxes = MultiLayerQG.fluxes(prob)
 
   return CUDA.@allowscalar isapprox(lateralfluxes[1], 0.00626267, rtol=1e-6) && CUDA.@allowscalar isapprox(lateralfluxes[2], 0, atol=1e-12) && CUDA.@allowscalar isapprox(verticalfluxes[1], -0.196539, rtol=1e-6)
 end
@@ -429,12 +429,12 @@ function test_mqg_fluxessinglelayer(dev::Device=CPU(); dt=0.001, stepper="Forwar
   U = zeros(ny, nlayers)
   U = @. sech(gr.y / 0.2)^2
 
-  prob = MultilayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=Lx, Ly=Ly, U=U)
+  prob = MultiLayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=Lx, Ly=Ly, U=U)
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   ψ = @. cos(k₀*x) * cos(l₀*y) + sin(k₀*x)
-  MultilayerQG.set_ψ!(prob, ψ)
-  lateralfluxes = MultilayerQG.fluxes(prob)
+  MultiLayerQG.set_ψ!(prob, ψ)
+  lateralfluxes = MultiLayerQG.fluxes(prob)
 
   return CUDA.@allowscalar isapprox(lateralfluxes[1], 0.0313134, atol=1e-7)
 end
@@ -458,7 +458,7 @@ function test_mqg_setqsetψ(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler",
   H = [0.2, 0.8]    # q1 = Δψ1 + 25*(ψ2-ψ1), and
   ρ = [4.0, 5.0]    # q2 = Δψ2 + 25/4*(ψ1-ψ2).
 
-  prob = MultilayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ)
+  prob = MultiLayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ)
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   T = eltype(gr)
@@ -470,15 +470,15 @@ function test_mqg_setqsetψ(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler",
   f[:, :, 2] .= f2
 
   ψtest = zeros(dev, T, size(f))
-  MultilayerQG.set_ψ!(prob, f)
+  MultiLayerQG.set_ψ!(prob, f)
   @. vs.qh = sol
-  MultilayerQG.streamfunctionfrompv!(vs.ψh, vs.qh, pr, gr)
-  MultilayerQG.invtransform!(ψtest, vs.ψh, pr)
+  MultiLayerQG.streamfunctionfrompv!(vs.ψh, vs.qh, pr, gr)
+  MultiLayerQG.invtransform!(ψtest, vs.ψh, pr)
 
   qtest = zeros(dev, T, size(f))
-  MultilayerQG.set_q!(prob, f)
+  MultiLayerQG.set_q!(prob, f)
   @. vs.qh = sol
-  MultilayerQG.invtransform!(qtest, vs.qh, pr)
+  MultiLayerQG.invtransform!(qtest, vs.qh, pr)
 
   return isapprox(ψtest, f, rtol=rtol_multilayerqg) && isapprox(qtest, f, rtol=rtol_multilayerqg)
 end
@@ -511,15 +511,15 @@ function test_mqg_paramsconstructor(dev::Device=CPU(); dt=0.001, stepper="Forwar
   CUDA.@allowscalar Ufloats[1] = U1
   CUDA.@allowscalar Ufloats[2] = U2
 
-  probUvectors = MultilayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ, U=Uvectors)
-  probUfloats = MultilayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ, U=Ufloats)
+  probUvectors = MultiLayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ, U=Uvectors)
+  probUfloats = MultiLayerQG.Problem(nlayers, dev; nx=nx, ny=ny, Lx=L, f₀=f₀, g=g, H=H, ρ=ρ, U=Ufloats)
 
   return isapprox(probUfloats.params.U, probUvectors.params.U, rtol=rtol_multilayerqg)
 end
 
 function test_mqg_problemtype(dev, T)
-  prob1 = MultilayerQG.Problem(1, dev; T=T)
-  prob2 = MultilayerQG.Problem(2, dev; T=T)
+  prob1 = MultiLayerQG.Problem(1, dev; T=T)
+  prob2 = MultiLayerQG.Problem(2, dev; T=T)
   
   A = ArrayType(dev)
   
@@ -539,7 +539,7 @@ function test_mqg_rossbywave(stepper, dt, nsteps, dev::Device=CPU())
         β = 2
         U = 0.5
 
-  prob = MultilayerQG.Problem(nlayers, dev; nx=nx, Lx=Lx, U=U, β=β, stepper=stepper, dt=dt)
+  prob = MultiLayerQG.Problem(nlayers, dev; nx=nx, Lx=Lx, U=U, β=β, stepper=stepper, dt=dt)
   sol, cl, v, p, g = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 
   x, y = gridpoints(g)
@@ -551,11 +551,11 @@ function test_mqg_rossbywave(stepper, dt, nsteps, dev::Device=CPU())
      q0 = @. ampl * cos(kwave * x) * cos(lwave * y)
      ψ0 = @. - q0 / (kwave^2 + lwave^2)
 
-  MultilayerQG.set_q!(prob, q0)
+  MultiLayerQG.set_q!(prob, q0)
 
   stepforward!(prob, nsteps)
   dealias!(sol, g)
-  MultilayerQG.updatevars!(prob)
+  MultiLayerQG.updatevars!(prob)
 
   q_theory = @. ampl * cos(kwave * (x - ω / kwave * cl.t)) * cos(lwave * y)
 
@@ -563,10 +563,10 @@ function test_mqg_rossbywave(stepper, dt, nsteps, dev::Device=CPU())
 end
 
 function test_numberoflayers(dev::Device=CPU())
-  prob_nlayers1 = MultilayerQG.Problem(1, dev)
-  prob_nlayers2 = MultilayerQG.Problem(2, dev)
+  prob_nlayers1 = MultiLayerQG.Problem(1, dev)
+  prob_nlayers2 = MultiLayerQG.Problem(2, dev)
   
-  return MultilayerQG.numberoflayers(prob_nlayers1)==1 && MultilayerQG.numberoflayers(prob_nlayers2)==2
+  return MultiLayerQG.numberoflayers(prob_nlayers1)==1 && MultiLayerQG.numberoflayers(prob_nlayers2)==2
 end
 
 function test_mqg_stochasticforcedproblemconstructor(dev::Device=CPU())
@@ -576,7 +576,7 @@ function test_mqg_stochasticforcedproblemconstructor(dev::Device=CPU())
     return nothing
   end
        
-  prob = MultilayerQG.Problem(2, dev; calcFq=calcFq!, stochastic=true)
+  prob = MultiLayerQG.Problem(2, dev; calcFq=calcFq!, stochastic=true)
   
   return typeof(prob.vars.prevsol)==typeof(prob.sol)
 end


### PR DESCRIPTION
Renames `MultilayerQG` module to `MultiLayerQG`.

This PR introduced breaking changed and should come with the minor release.

Closes #169.