### PR TITLE
Improvements in TwoDNavierStokes

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -102,7 +102,7 @@ sitename = "GeophysicalFlows.jl",
 )
 
 withenv("GITHUB_REPOSITORY" => "FourierFlows/GeophysicalFlowsDocumentation") do
-  deploydocs(        repo = "github.com/FourierFlows/GeophysicalFlowsDocumentation.git",
+  deploydocs(       repo = "github.com/FourierFlows/GeophysicalFlowsDocumentation.git",
                 versions = ["stable" => "v^", "v#.#", "dev" => "dev"],
             push_preview = false
             )

--- a/docs/src/modules/twodnavierstokes.md
+++ b/docs/src/modules/twodnavierstokes.md
@@ -62,30 +62,28 @@ GeophysicalFlows.TwoDNavierStokes.addforcing!
 
 **Params**
 
-For the unforced case (``f=0``) parameters AbstractType is build with `Params` and it includes:
-- `ν`:   Float; viscosity or hyperviscosity coefficient.
-- `nν`: Integer ``>0``; the order of viscosity ``n_ν``. Case ``n_ν = 1`` gives normal viscosity.
-- `μ`: Float; bottom drag or hypoviscosity coefficient.
-- `nμ`: Integer ``\ge 0``; the order of hypodrag ``n_μ``. Case ``n_μ = 0`` gives plain linear drag ``μ``.
-
-For the forced case (``F\ne 0``) parameters AbstractType is build with `ForcedParams`. It includes all parameters in `Params` and additionally:
-- `calcF!`: Function that calculates the forcing ``\widehat{F}``
-
+For the unforced case (``F = 0``), the `params` struct is build with `Params` and it includes:
+- `ν :: Float`: small-scale (hyper)-viscosity coefficient,
+- `nν :: Int`: (hyper)-viscosity order, `nν ≥ 1`,
+- `μ :: Float`: large-scale (hypo)-viscosity coefficient,
+- `nμ :: Int`: (hypo)-viscosity order, `nν ≤ 0`,
+- `calcF :: Function`: Function that computes the forcing ``F̂``.
 
 **Vars**
 
-For the unforced case (``F=0``) variables AbstractType is build with `Vars` and it includes:
-- `ζ`: Array of Floats; relative vorticity.
-- `u`: Array of Floats; ``x``-velocity, ``u``.
-- `v`: Array of Floats; ``y``-velocity, ``v``.
-- `sol`: Array of Complex; the solution, ``\widehat{\zeta}``.
-- `ζh`: Array of Complex; the Fourier transform ``\widehat{\zeta}``.
-- `uh`: Array of Complex; the Fourier transform ``\widehat{u}``.
-- `vh`: Array of Complex; the Fourier transform ``\widehat{v}``.
+For the unforced case (``F=0``) the `vars` struct with `Vars` and it includes:
+- `ζ :: Array{Float}`: relative vorticity, ``ζ``,
+- `u :: Array{Float}`: ``x``-velocity, ``u``,
+- `v :: Array{Float}`: ``y``-velocity, ``v``,
+- `ζh :: Array{Complex{Float}}`: the Fourier transform of ``ζ``,
+- `uh :: Array{Complex{Float}}`: the Fourier transform of ``u``,
+- `vh :: Array{Complex{Float}}`: the Fourier transform of ``v``.
 
-For the forced case (``f \ne 0``) variables AbstractType is build with `ForcedVars`. It includes all variables in `Vars` and additionally:
-- `Fh`: Array of Complex; the Fourier transform ``\widehat{f}``.
-- `prevsol`: Array of Complex; the values of the solution `sol` at the previous time-step (useful for calculating the work done by the forcing).
+The state variable `sol` is `ζh`.
+
+For the forced case (``F \ne 0``) the `vars` struct is build with `ForcedVars` or `StochasticForcedVars`. It includes all variables in `Vars` and additionally:
+- `Fh :: Complex{Float}`: the Fourier transform ``\widehat{f}``.
+- `prevsol :: Array{Complex{Float}}`: the solution `sol` at the previous time-step (needed to calculate the work done by the forcing when forcing is stochastic).
 
 ### Helper functions
 
@@ -102,33 +100,18 @@ GeophysicalFlows.TwoDNavierStokes.set_ζ!
 
 ```@docs
 GeophysicalFlows.TwoDNavierStokes.energy
-```
-
-```@docs
 GeophysicalFlows.TwoDNavierStokes.enstrophy
 ```
 
 ```@docs
 GeophysicalFlows.TwoDNavierStokes.energy_dissipation
-```
-
-```@docs
-GeophysicalFlows.TwoDNavierStokes.enstrophy_dissipation
-```
-
-```@docs
 GeophysicalFlows.TwoDNavierStokes.energy_drag
-```
-
-```@docs
-GeophysicalFlows.TwoDNavierStokes.enstrophy_drag
-```
-
-```@docs
 GeophysicalFlows.TwoDNavierStokes.energy_work
 ```
 
 ```@docs
+GeophysicalFlows.TwoDNavierStokes.enstrophy_dissipation
+GeophysicalFlows.TwoDNavierStokes.enstrophy_drag
 GeophysicalFlows.TwoDNavierStokes.enstrophy_work
 ```
 

--- a/docs/src/modules/twodnavierstokes.md
+++ b/docs/src/modules/twodnavierstokes.md
@@ -105,13 +105,11 @@ GeophysicalFlows.TwoDNavierStokes.enstrophy
 
 ```@docs
 GeophysicalFlows.TwoDNavierStokes.energy_dissipation
-GeophysicalFlows.TwoDNavierStokes.energy_drag
 GeophysicalFlows.TwoDNavierStokes.energy_work
 ```
 
 ```@docs
 GeophysicalFlows.TwoDNavierStokes.enstrophy_dissipation
-GeophysicalFlows.TwoDNavierStokes.enstrophy_drag
 GeophysicalFlows.TwoDNavierStokes.enstrophy_work
 ```
 

--- a/docs/src/modules/twodnavierstokes.md
+++ b/docs/src/modules/twodnavierstokes.md
@@ -67,7 +67,7 @@ For the unforced case (``F = 0``), the `params` struct is build with `Params` an
 - `nν :: Int`: (hyper)-viscosity order, `nν ≥ 1`,
 - `μ :: Float`: large-scale (hypo)-viscosity coefficient,
 - `nμ :: Int`: (hypo)-viscosity order, `nν ≤ 0`,
-- `calcF :: Function`: Function that computes the forcing ``F̂``.
+- `calcF! :: Function`: Function that computes the forcing ``F̂``.
 
 **Vars**
 

--- a/docs/src/modules/twodnavierstokes.md
+++ b/docs/src/modules/twodnavierstokes.md
@@ -3,77 +3,134 @@
 
 ### Basic Equations
 
-This module solves two-dimensional incompressible turbulence. The flow is given
-through a streamfunction $\psi$ as $(u,\upsilon) = (-\partial_y\psi, \partial_x\psi)$.
-The dynamical variable used here is the component of the vorticity of the flow
-normal to the plane of motion, $\zeta=\partial_x \upsilon- \partial_y u = \nabla^2\psi$.
-The equation solved by the module is:
+This module solves two-dimensional incompressible Navier-Stokes equations using the 
+vorticity-streamfunction formulation. The flow ``\boldsymbol{u} = (u, v)`` is obtained through 
+a streamfunction ``\psi`` as ``(u, v) = (-\partial_y \psi, \partial_x \psi)``. The only non-zero 
+component of vorticity is that normal to the plane of motion, 
+``\partial_x v - \partial_y u = \nabla^2 \psi``. The equation solved by the module is:
 
-$$\partial_t \zeta + \mathsf{J}(\psi, \zeta) = \underbrace{-\left[\mu(-1)^{n_\mu} \nabla^{2n_\mu}
-+\nu(-1)^{n_\nu} \nabla^{2n_\nu}\right] \zeta}_{\textrm{dissipation}} + f\ .$$
+```math
+\partial_t \zeta + \mathsf{J}(\psi, \zeta) = \underbrace{-\left [ \mu (-\nabla^2)^{n_\mu}
++ \nu (-\nabla^2)^{n_\nu} \right ] \zeta}_{\textrm{dissipation}} + F \ .
+```
 
-where $\mathsf{J}(a, b) = (\partial_x a)(\partial_y b)-(\partial_y a)(\partial_x b)$. On
-the right hand side, $f(x,y,t)$ is forcing, $\mu$ is hypoviscosity, and $\nu$ is
-hyperviscosity. Plain old linear drag corresponds to $n_{\mu}=0$, while normal
-viscosity corresponds to $n_{\nu}=1$.
+where ``\mathsf{J}(a, b) = (\partial_x a)(\partial_y b) - (\partial_y a)(\partial_x b)``. On
+the right hand side, ``F(x, y, t)`` is forcing. The ``ν`` and ``μ`` terms are both viscosities 
+and typically the former is chosen to act at small scales (``n_ν ≥ 1``) and the latter at 
+large scales (``n_ν ≤ 1``). Plain old viscocity corresponds to ``n_ν=1`` while ``n_μ=0`` 
+corresponds to linear drag. Values of ``n_ν ≥ 2`` and ``n_μ ≤ -1`` are referred to as 
+hyper- and hypo-viscosities, respectively.
+
 
 ### Implementation
 
 The equation is time-stepped forward in Fourier space:
 
-$$\partial_t \widehat{\zeta} = - \widehat{\mathsf{J}(\psi, \zeta)} -\left(\mu k^{2n_\mu}
-+\nu k^{2n_\nu}\right) \widehat{\zeta}  + \widehat{f}\ .$$
+```math
+\partial_t \widehat{\zeta} = - \widehat{\mathsf{J}(\psi, \zeta )} - \left ( \mu |𝐤|^{2n_\mu}
++ \nu |𝐤|^{2n_\nu} \right ) \widehat{\zeta} + \widehat{f} \ .
+```
 
-In doing so the Jacobian is computed in the conservative form: $\mathsf{J}(a,b) =
-\partial_y [ (\partial_x a) b] -\partial_x[ (\partial_y a) b]$.
+In doing so the Jacobian is computed in the conservative form: ``\mathsf{J}(a,b) =
+\partial_y [ (\partial_x a) b] -\partial_x[ (\partial_y a) b]``.
 
-Thus:
+The linear operator is constructed in `Equation`
 
-$$\mathcal{L} = -\mu k^{-2n_\mu} - \nu k^{2n_\nu}\ ,$$
-$$\mathcal{N}(\widehat{\zeta}) = - \mathrm{i}k_x \mathrm{FFT}(u \zeta)-
-	\mathrm{i}k_y \mathrm{FFT}(\upsilon \zeta) + \widehat{f}\ .$$
+```@docs
+GeophysicalFlows.TwoDNavierStokes.Equation
+```
+
+The nonlinear terms is computed via
+
+```@docs
+GeophysicalFlows.TwoDNavierStokes.calcN!
+```
+
+which, in turn, calls 
+
+```@docs
+GeophysicalFlows.TwoDNavierStokes.calcN_advection!
+```
+and
+
+```@docs
+GeophysicalFlows.TwoDNavierStokes.addforcing!
+```
 
 
 ### AbstractTypes and Functions
 
 **Params**
 
-For the unforced case ($f=0$) parameters AbstractType is build with `Params` and it includes:
+For the unforced case (``f=0``) parameters AbstractType is build with `Params` and it includes:
 - `ν`:   Float; viscosity or hyperviscosity coefficient.
-- `nν`: Integer$>0$; the order of viscosity $n_\nu$. Case $n_\nu=1$ gives normal viscosity.
+- `nν`: Integer ``>0``; the order of viscosity ``n_ν``. Case ``n_ν = 1`` gives normal viscosity.
 - `μ`: Float; bottom drag or hypoviscosity coefficient.
-- `nμ`: Integer$\ge 0$; the order of hypodrag $n_\mu$. Case $n_\mu=0$ gives plain linear drag $\mu$.
+- `nμ`: Integer ``\ge 0``; the order of hypodrag ``n_μ``. Case ``n_μ = 0`` gives plain linear drag ``μ``.
 
-For the forced case ($f\ne 0$) parameters AbstractType is build with `ForcedParams`. It includes all parameters in `Params` and additionally:
-- `calcF!`: Function that calculates the forcing $\widehat{f}$
+For the forced case (``F\ne 0``) parameters AbstractType is build with `ForcedParams`. It includes all parameters in `Params` and additionally:
+- `calcF!`: Function that calculates the forcing ``\widehat{F}``
 
 
 **Vars**
 
-For the unforced case ($f=0$) variables AbstractType is build with `Vars` and it includes:
-- `zeta`: Array of Floats; relative vorticity.
-- `u`: Array of Floats; $x$-velocity, $u$.
-- `v`: Array of Floats; $y$-velocity, $\upsilon$.
-- `sol`: Array of Complex; the solution, $\widehat{\zeta}$.
-- `zetah`: Array of Complex; the Fourier transform $\widehat{\zeta}$.
-- `uh`: Array of Complex; the Fourier transform $\widehat{u}$.
-- `vh`: Array of Complex; the Fourier transform $\widehat{\upsilon}$.
+For the unforced case (``F=0``) variables AbstractType is build with `Vars` and it includes:
+- `ζ`: Array of Floats; relative vorticity.
+- `u`: Array of Floats; ``x``-velocity, ``u``.
+- `v`: Array of Floats; ``y``-velocity, ``v``.
+- `sol`: Array of Complex; the solution, ``\widehat{\zeta}``.
+- `ζh`: Array of Complex; the Fourier transform ``\widehat{\zeta}``.
+- `uh`: Array of Complex; the Fourier transform ``\widehat{u}``.
+- `vh`: Array of Complex; the Fourier transform ``\widehat{v}``.
 
-For the forced case ($f\ne 0$) variables AbstractType is build with `ForcedVars`. It includes all variables in `Vars` and additionally:
-- `Fh`: Array of Complex; the Fourier transform $\widehat{f}$.
+For the forced case (``f \ne 0``) variables AbstractType is build with `ForcedVars`. It includes all variables in `Vars` and additionally:
+- `Fh`: Array of Complex; the Fourier transform ``\widehat{f}``.
 - `prevsol`: Array of Complex; the values of the solution `sol` at the previous time-step (useful for calculating the work done by the forcing).
 
+### Helper functions
+
+```@docs
+GeophysicalFlows.TwoDNavierStokes.updatevars!
+```
+
+```@docs
+GeophysicalFlows.TwoDNavierStokes.set_ζ!
+```
 
 
-**`calcN!` function**
+### Diagnostics
 
-The nonlinear term $\mathcal{N}(\widehat{\zeta})$ is computed via functions:
+```@docs
+GeophysicalFlows.TwoDNavierStokes.energy
+```
 
-- `calcN_advection!`: computes $- \widehat{\mathsf{J}(\psi, \zeta)}$ and stores it in array `N`.
+```@docs
+GeophysicalFlows.TwoDNavierStokes.enstrophy
+```
 
-- `calcN_forced!`: computes $- \widehat{\mathsf{J}(\psi, \zeta)}$ via `calcN_advection!` and then adds to it the forcing $\widehat{f}$ computed via `calcF!` function. Also saves the solution $\widehat{\zeta}$ of the previous time-step in array `prevsol`.
+```@docs
+GeophysicalFlows.TwoDNavierStokes.energy_dissipation
+```
 
-- `updatevars!`: uses `sol` to compute $\zeta$, $u$, $\upsilon$, $\widehat{u}$, and $\widehat{\upsilon}$ and stores them into corresponding arrays of `Vars`/`ForcedVars`.
+```@docs
+GeophysicalFlows.TwoDNavierStokes.enstrophy_dissipation
+```
+
+```@docs
+GeophysicalFlows.TwoDNavierStokes.energy_drag
+```
+
+```@docs
+GeophysicalFlows.TwoDNavierStokes.enstrophy_drag
+```
+
+```@docs
+GeophysicalFlows.TwoDNavierStokes.energy_work
+```
+
+```@docs
+GeophysicalFlows.TwoDNavierStokes.enstrophy_work
+```
 
 
 ## Examples
@@ -83,3 +140,5 @@ The nonlinear term $\mathcal{N}(\widehat{\zeta})$ is computed via functions:
   > McWilliams, J. C. (1984). The emergence of isolated coherent vortices in turbulent flow. *J. Fluid Mech.*, **146**, 21-43.
 
 - `examples/twodnavierstokes_stochasticforcing.jl`: A script that simulates forced-dissipative two-dimensional turbulence with isotropic temporally delta-correlated stochastic forcing.
+
+- `examples/twodnavierstokes_stochasticforcing_budgets.jl`: A script that simulates forced-dissipative two-dimensional turbulence demonstrating how we can compute the energy and enstrophy budgets.

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -54,11 +54,11 @@ nothing # hide
 seed!(1234)
 k₀, E₀ = 6, 0.5
 ζ₀ = peakedisotropicspectrum(grid, k₀, E₀, mask=prob.timestepper.filter)
-TwoDNavierStokes.set_zeta!(prob, ζ₀)
+TwoDNavierStokes.set_ζ!(prob, ζ₀)
 nothing # hide
 
 # Let's plot the initial vorticity field:
-heatmap(x, y, vars.zeta',
+heatmap(x, y, vars.ζ',
          aspectratio = 1,
               c = :balance,
            clim = (-40, 40),
@@ -108,7 +108,7 @@ nothing # hide
 # We initialize a plot with the vorticity field and the time-series of
 # energy and enstrophy diagnostics.
 
-p1 = heatmap(x, y, vars.zeta',
+p1 = heatmap(x, y, vars.ζ',
          aspectratio = 1,
                    c = :balance,
                 clim = (-40, 40),
@@ -150,7 +150,7 @@ anim = @animate for j = 0:Int(nsteps/nsubs)
     println(log)
   end  
 
-  p[1][1][:z] = vars.zeta
+  p[1][1][:z] = vars.ζ
   p[1][:title] = "vorticity, t=" * @sprintf("%.2f", clock.t)
   push!(p[2][1], E.t[E.i], E.data[E.i]/E.data[1])
   push!(p[2][2], Z.t[Z.i], Z.data[Z.i]/Z.data[1])

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -61,8 +61,8 @@ seed!(1234)
 nothing # hide
 
 # Next we construct function `calcF!` that computes a forcing realization every timestep
-function calcF!(Fh, sol, t, clock, vars, params, grid)
-  ξ = ArrayType(dev)(exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt))
+function calcF!(Fh, sol, t, clock, vars, params, grid::AbstractGrid{T, A}) where {T, A}
+  ξ = A(exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt))
   ξ[1, 1] = 0
   @. Fh = ξ * sqrt(forcing_spectrum)
   
@@ -107,7 +107,7 @@ heatmap(x, y, irfft(vars.Fh, grid.nx)',
 # ## Setting initial conditions
 
 # Our initial condition is a fluid at rest.
-TwoDNavierStokes.set_zeta!(prob, zeros(grid.nx, grid.ny))
+TwoDNavierStokes.set_ζ!(prob, zeros(grid.nx, grid.ny))
 
 
 # ## Diagnostics
@@ -125,7 +125,7 @@ nothing # hide
 # energy and enstrophy diagnostics. To plot energy and enstrophy on the same
 # axes we scale enstrophy with $k_f^2$.
 
-p1 = heatmap(x, y, vars.zeta',
+p1 = heatmap(x, y, vars.ζ',
          aspectratio = 1,
                    c = :balance,
                 clim = (-40, 40),
@@ -166,7 +166,7 @@ anim = @animate for j = 0:round(Int, nsteps / nsubs)
     println(log)
   end  
 
-  p[1][1][:z] = vars.zeta
+  p[1][1][:z] = vars.ζ
   p[1][:title] = "vorticity, μt = " * @sprintf("%.2f", μ * clock.t)
   push!(p[2][1], μ * E.t[E.i], E.data[E.i])
   push!(p[2][2], μ * Z.t[Z.i], Z.data[Z.i] / forcing_wavenumber^2)

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -61,8 +61,8 @@ seed!(1234)
 nothing # hide
 
 # Next we construct function `calcF!` that computes a forcing realization every timestep
-function calcF!(Fh, sol, t, clock, vars, params, grid::AbstractGrid{T, A}) where {T, A}
-  ξ = A(exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt))
+function calcF!(Fh, sol, t, clock, vars, params, grid)
+  ξ = ArrayType(dev)(exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt))
   ξ[1, 1] = 0
   @. Fh = ξ * sqrt(forcing_spectrum)
   

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -16,8 +16,8 @@ using Random: seed!
 using FFTW: irfft
 
 import GeophysicalFlows.TwoDNavierStokes
-import GeophysicalFlows.TwoDNavierStokes: energy, energy_dissipation, energy_work, energy_drag
-import GeophysicalFlows.TwoDNavierStokes: enstrophy, enstrophy_dissipation, enstrophy_work, enstrophy_drag
+import GeophysicalFlows.TwoDNavierStokes: energy, energy_dissipation_hyperviscosity, energy_dissipation_hypoviscosity, energy_work
+import GeophysicalFlows.TwoDNavierStokes: enstrophy, enstrophy_dissipation_hyperviscosity, enstrophy_dissipation_hypoviscosity, enstrophy_work
 
 
 # ## Choosing a device: CPU or GPU
@@ -117,14 +117,14 @@ TwoDNavierStokes.set_ζ!(prob, zeros(grid.nx, grid.ny))
 # ## Diagnostics
 
 # Create Diagnostics; the diagnostics are aimed to probe the energy and enstrophy budgets.
-E  = Diagnostic(energy,                prob, nsteps=nt) # energy
-Rᵋ = Diagnostic(energy_drag,           prob, nsteps=nt) # energy dissipation by drag
-Dᵋ = Diagnostic(energy_dissipation,    prob, nsteps=nt) # energy dissipation by hyperviscosity
-Wᵋ = Diagnostic(energy_work,           prob, nsteps=nt) # energy work input by forcing
-Z  = Diagnostic(enstrophy,             prob, nsteps=nt) # enstrophy
-Rᶻ = Diagnostic(enstrophy_drag,        prob, nsteps=nt) # enstrophy dissipation by drag
-Dᶻ = Diagnostic(enstrophy_dissipation, prob, nsteps=nt) # enstrophy dissipation by hyperviscosity
-Wᶻ = Diagnostic(enstrophy_work,        prob, nsteps=nt) # enstrophy work input by forcing
+E  = Diagnostic(energy,                               prob, nsteps=nt) # energy
+Rᵋ = Diagnostic(energy_dissipation_hypoviscosity,     prob, nsteps=nt) # energy dissipation by drag μ
+Dᵋ = Diagnostic(energy_dissipation_hyperviscosity,    prob, nsteps=nt) # energy dissipation by drag μ
+Wᵋ = Diagnostic(energy_work,                          prob, nsteps=nt) # energy work input by forcing
+Z  = Diagnostic(enstrophy,                            prob, nsteps=nt) # enstrophy
+Rᶻ = Diagnostic(enstrophy_dissipation_hypoviscosity,  prob, nsteps=nt) # enstrophy dissipation by drag μ
+Dᶻ = Diagnostic(enstrophy_dissipation_hyperviscosity, prob, nsteps=nt) # enstrophy dissipation by drag μ
+Wᶻ = Diagnostic(enstrophy_work,                       prob, nsteps=nt) # enstrophy work input by forcing
 diags = [E, Dᵋ, Wᵋ, Rᵋ, Z, Dᶻ, Wᶻ, Rᶻ] # a list of Diagnostics passed to `stepforward!` will  be updated every timestep.
 nothing # hide
 

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -111,7 +111,7 @@ heatmap(x, y, irfft(vars.Fh, grid.nx)',
 # ## Setting initial conditions
 
 # Our initial condition is a fluid at rest.
-TwoDNavierStokes.set_zeta!(prob, zeros(grid.nx, grid.ny))
+TwoDNavierStokes.set_ζ!(prob, zeros(grid.nx, grid.ny))
 
 
 # ## Diagnostics
@@ -149,15 +149,15 @@ function computetendencies_and_makeplot(prob, diags)
   dEdt_numerical = (E[2:E.i] - E[1:E.i-1]) / clock.dt # numerical first-order approximation of energy tendency
   dZdt_numerical = (Z[2:Z.i] - Z[1:Z.i-1]) / clock.dt # numerical first-order approximation of enstrophy tendency
 
-  dEdt_computed = Wᵋ[2:E.i] - Dᵋ[1:E.i-1] - Rᵋ[1:E.i-1]
-  dZdt_computed = Wᶻ[2:Z.i] - Dᶻ[1:Z.i-1] - Rᶻ[1:Z.i-1]
+  dEdt_computed = Wᵋ[2:E.i] + Dᵋ[1:E.i-1] + Rᵋ[1:E.i-1]
+  dZdt_computed = Wᶻ[2:Z.i] + Dᶻ[1:Z.i-1] + Rᶻ[1:Z.i-1]
 
   residual_E = dEdt_computed - dEdt_numerical
   residual_Z = dZdt_computed - dZdt_numerical
 
   εᶻ = parsevalsum(forcing_spectrum / 2, grid) / (grid.Lx * grid.Ly)
 
-  pzeta = heatmap(x, y, vars.zeta',
+  pζ = heatmap(x, y, vars.ζ',
             aspectratio = 1,
             legend = false,
                  c = :viridis,
@@ -171,11 +171,11 @@ function computetendencies_and_makeplot(prob, diags)
              title = "∇²ψ(x, y, μt=" * @sprintf("%.2f", μ * clock.t) * ")",
         framestyle = :box)
 
-  pζ = plot(pzeta, size = (400, 400))
+  pζ = plot(pζ, size = (400, 400))
 
   t = E.t[2:E.i]
 
-  p1E = plot(μ * t, [Wᵋ[2:E.i] ε.+0*t -Dᵋ[1:E.i-1] -Rᵋ[1:E.i-1]],
+  p1E = plot(μ * t, [Wᵋ[2:E.i] ε.+0*t + Dᵋ[1:E.i-1] + Rᵋ[1:E.i-1]],
              label = ["energy work, Wᵋ" "ensemble mean energy work, <Wᵋ>" "dissipation, Dᵋ" "drag, Rᵋ = - 2μE"],
          linestyle = [:solid :dash :solid :solid],
          linewidth = 2,
@@ -199,7 +199,7 @@ function computetendencies_and_makeplot(prob, diags)
 
   t = Z.t[2:E.i]
 
-  p1Z = plot(μ * t, [Wᶻ[2:Z.i] εᶻ.+0*t -Dᶻ[1:Z.i-1] -Rᶻ[1:Z.i-1]],
+  p1Z = plot(μ * t, [Wᶻ[2:Z.i] εᶻ.+0*t + Dᶻ[1:Z.i-1] + Rᶻ[1:Z.i-1]],
            label = ["enstrophy work, Wᶻ" "mean enstrophy work, <Wᶻ>" "enstrophy dissipation, Dᶻ" "enstrophy drag, Rᶻ = - 2μZ"],
        linestyle = [:solid :dash :solid :solid],
        linewidth = 2,

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -175,7 +175,7 @@ function computetendencies_and_makeplot(prob, diags)
 
   t = E.t[2:E.i]
 
-  p1E = plot(μ * t, [Wᵋ[2:E.i] ε.+0*t + Dᵋ[1:E.i-1] + Rᵋ[1:E.i-1]],
+  p1E = plot(μ * t, [Wᵋ[2:E.i] ε.+0*t Dᵋ[1:E.i-1] Rᵋ[1:E.i-1]],
              label = ["energy work, Wᵋ" "ensemble mean energy work, <Wᵋ>" "dissipation, Dᵋ" "drag, Rᵋ = - 2μE"],
          linestyle = [:solid :dash :solid :solid],
          linewidth = 2,
@@ -199,7 +199,7 @@ function computetendencies_and_makeplot(prob, diags)
 
   t = Z.t[2:E.i]
 
-  p1Z = plot(μ * t, [Wᶻ[2:Z.i] εᶻ.+0*t + Dᶻ[1:Z.i-1] + Rᶻ[1:Z.i-1]],
+  p1Z = plot(μ * t, [Wᶻ[2:Z.i] εᶻ.+0*t Dᶻ[1:Z.i-1] Rᶻ[1:Z.i-1]],
            label = ["enstrophy work, Wᶻ" "mean enstrophy work, <Wᶻ>" "enstrophy dissipation, Dᶻ" "enstrophy drag, Rᶻ = - 2μZ"],
        linestyle = [:solid :dash :solid :solid],
        linewidth = 2,

--- a/src/twodnavierstokes.jl
+++ b/src/twodnavierstokes.jl
@@ -2,7 +2,7 @@ module TwoDNavierStokes
 
 export
   Problem,
-  set_zeta!,
+  set_ζ!,
   updatevars!,
 
   energy,
@@ -26,9 +26,9 @@ using FourierFlows: parsevalsum
 nothingfunction(args...) = nothing
 
 """
-    Problem(; parameters...)
+    Problem(dev::Device; parameters...)
 
-Construct a 2D turbulence problem.
+Construct a 2D Navier-Stokes problem.
 """
 function Problem(dev::Device=CPU();
   # Numerical parameters
@@ -67,14 +67,14 @@ end
 """
     Params(ν, nν, μ, nμ, calcF!)
 
-Returns the params for two-dimensional turbulence.
+Returns the params for two-dimensional Navier-Stokes.
 """
 struct Params{T} <: AbstractParams
-       ν :: T         # Vorticity viscosity
-      nν :: Int       # Vorticity hyperviscous order
-       μ :: T         # Bottom drag or hypoviscosity
-      nμ :: Int       # Order of hypodrag
-  calcF! :: Function  # Function that calculates the forcing F
+       ν :: T         # Viscosity
+      nν :: Int       # Hyperviscous order
+       μ :: T         # Hypoviscosity
+      nμ :: Int       # Hypoviscosity order
+  calcF! :: Function  # Function that calculates the forcing F̂
 end
 
 Params(ν, nν) = Params(ν, nν, typeof(ν)(0), 0, nothingfunction)
@@ -87,11 +87,21 @@ Params(ν, nν) = Params(ν, nν, typeof(ν)(0), 0, nothingfunction)
 """
     Equation(params, grid)
 
-Returns the equation for two-dimensional turbulence with `params` and `grid`.
+Returns the `equation` for two-dimensional Navier-Stokes with `params` and `grid`. The linear
+opeartor ``L`` includes (hyper)-viscosity of order ``n_ν`` with coefficient ``ν`` and 
+hypo-viscocity of order ``n_μ`` with coefficient ``μ``. Plain old viscocity corresponds to 
+``n_ν=1`` while ``n_μ=0`` corresponds to linear drag.
+
+```math
+L = - ν |𝐤|^{2 n_ν} - μ |𝐤|^{2 n_μ} .
+```
+
+The nonlinear term is computed via function `calcN!()`.
 """
 function Equation(params::Params, grid::AbstractGrid)
   L = @. - params.ν * grid.Krsq^params.nν - params.μ * grid.Krsq^params.nμ
   CUDA.@allowscalar L[1, 1] = 0
+  
   return FourierFlows.Equation(L, calcN!, grid)
 end
 
@@ -103,10 +113,10 @@ end
 abstract type TwoDNavierStokesVars <: AbstractVars end
 
 struct Vars{Aphys, Atrans, F, P} <: TwoDNavierStokesVars
-     zeta :: Aphys
+        ζ :: Aphys
         u :: Aphys
         v :: Aphys
-    zetah :: Atrans
+       ζh :: Atrans
        uh :: Atrans
        vh :: Atrans
        Fh :: F
@@ -119,37 +129,39 @@ const StochasticForcedVars = Vars{<:AbstractArray, <:AbstractArray, <:AbstractAr
 """
     Vars(dev, grid)
 
-Returns the `vars` for unforced two-dimensional turbulence on device `dev` and with `grid`.
+Returns the `vars` for unforced two-dimensional Navier-Stokes problem on device `dev` and 
+with `grid`.
 """
 function Vars(::Dev, grid::AbstractGrid) where Dev
   T = eltype(grid)
-  @devzeros Dev T (grid.nx, grid.ny) zeta u v
-  @devzeros Dev Complex{T} (grid.nkr, grid.nl) zetah uh vh
-  return Vars(zeta, u, v, zetah, uh, vh, nothing, nothing)
+  @devzeros Dev T (grid.nx, grid.ny) ζ u v
+  @devzeros Dev Complex{T} (grid.nkr, grid.nl) ζh uh vh
+  return Vars(ζ, u, v, ζh, uh, vh, nothing, nothing)
 end
 
 """
     ForcedVars(dev, grid)
 
-Returns the vars for forced two-dimensional turbulence on device `dev` and with `grid`.
+Returns the vars for forced two-dimensional Navier-Stokes on device `dev` and with `grid`.
 """
 function ForcedVars(dev::Dev, grid::AbstractGrid) where Dev
   T = eltype(grid)
-  @devzeros Dev T (grid.nx, grid.ny) zeta u v
-  @devzeros Dev Complex{T} (grid.nkr, grid.nl) zetah uh vh Fh
-  return Vars(zeta, u, v, zetah, uh, vh, Fh, nothing)
+  @devzeros Dev T (grid.nx, grid.ny) ζ u v
+  @devzeros Dev Complex{T} (grid.nkr, grid.nl) ζh uh vh Fh
+  return Vars(ζ, u, v, ζh, uh, vh, Fh, nothing)
 end
 
 """
     StochasticForcedVars(dev, grid)
 
-Returns the vars for stochastically forced two-dimensional turbulence on device `dev` and with `grid`.
+Returns the vars for stochastically forced two-dimensional Navier-Stokes on device `dev` and 
+with `grid`.
 """
 function StochasticForcedVars(dev::Dev, grid::AbstractGrid) where Dev
   T = eltype(grid)
-  @devzeros Dev T (grid.nx, grid.ny) zeta u v
-  @devzeros Dev Complex{T} (grid.nkr, grid.nl) zetah uh vh Fh prevsol
-  return Vars(zeta, u, v, zetah, uh, vh, Fh, prevsol)
+  @devzeros Dev T (grid.nx, grid.ny) ζ u v
+  @devzeros Dev Complex{T} (grid.nkr, grid.nl) ζh uh vh Fh prevsol
+  return Vars(ζ, u, v, ζh, uh, vh, Fh, prevsol)
 end
 
 
@@ -158,44 +170,69 @@ end
 # -------
 
 """
-    calcN_advection(N, sol, t, clock, vars, params, grid)
+    calcN_advection!(N, sol, t, clock, vars, params, grid)
 
-Calculates the advection term.
+Calculates the Fourier transform of the advection term, ``- 𝖩(ψ, ζ)`` in conservative 
+form, i.e., ``- ∂_y[(∂_x ψ)ζ] + ∂_x[(∂_y ψ)ζ]`` and stores it in `N`:
+
+```math
+N(ζ̂) = - \\widehat{𝖩(ψ, ζ)} = - i k_x \\widehat{u ζ} - i k_y \\widehat{v ζ} .
+```
 """
 function calcN_advection!(N, sol, t, clock, vars, params, grid)
   @. vars.uh =   im * grid.l  * grid.invKrsq * sol
   @. vars.vh = - im * grid.kr * grid.invKrsq * sol
-  @. vars.zetah = sol
+  @. vars.ζh = sol
 
   ldiv!(vars.u, grid.rfftplan, vars.uh)
   ldiv!(vars.v, grid.rfftplan, vars.vh)
-  ldiv!(vars.zeta, grid.rfftplan, vars.zetah)
+  ldiv!(vars.ζ, grid.rfftplan, vars.ζh)
   
-  uζ = vars.u        # use vars.u as scratch variable
-  @. uζ *= vars.zeta # u*zeta
-  vζ = vars.v        # use vars.v as scratch variable
-  @. vζ *= vars.zeta # v*zeta
+  uζ = vars.u                  # use vars.u as scratch variable
+  @. uζ *= vars.ζ              # u*ζ
+  vζ = vars.v                  # use vars.v as scratch variable
+  @. vζ *= vars.ζ              # v*ζ
   
-  uζh = vars.uh
-  mul!(uζh, grid.rfftplan, uζ) # \hat{u*zeta}
-  vζh = vars.vh 
-  mul!(vζh, grid.rfftplan, vζ) # \hat{v*zeta}
+  uζh = vars.uh                # use vars.uh as scratch variable
+  mul!(uζh, grid.rfftplan, uζ) # \hat{u*ζ}
+  vζh = vars.vh                # use vars.vh as scratch variable
+  mul!(vζh, grid.rfftplan, vζ) # \hat{v*ζ}
 
   @. N = - im * grid.kr * uζh - im * grid.l * vζh
+  
   return nothing
 end
 
+"""
+    calcN!(N, sol, t, clock, vars, params, grid)
+
+Calculates the nonlinear term, that is the advection term and the forcing,
+
+```math
+N(ζ̂) = - \\widehat{𝖩(ψ, ζ)} + F̂ ,
+```
+
+by calling `calcN_advection!` and `addforcing!`.
+"""
 function calcN!(N, sol, t, clock, vars, params, grid)
   calcN_advection!(N, sol, t, clock, vars, params, grid)
   addforcing!(N, sol, t, clock, vars, params, grid)
+  
   return nothing
 end
 
+"""
+    addforcing!(N, sol, t, clock, vars, params, grid)
+
+When the problem includes forcing, calculate the forcing term ``F̂`` and add it to the 
+nonlinear term ``N``.
+"""
 addforcing!(N, sol, t, clock, vars::Vars, params, grid) = nothing
 
 function addforcing!(N, sol, t, clock, vars::ForcedVars, params, grid)
   params.calcF!(vars.Fh, sol, t, clock, vars, params, grid)
   @. N += vars.Fh
+  
   return nothing
 end
 
@@ -205,6 +242,7 @@ function addforcing!(N, sol, t, clock, vars::StochasticForcedVars, params, grid)
     params.calcF!(vars.Fh, sol, t, clock, vars, params, grid)
   end
   @. N += vars.Fh
+  
   return nothing
 end
 
@@ -220,22 +258,25 @@ Update variables in `vars` with solution in `sol`.
 """
 function updatevars!(prob)
   vars, grid, sol = prob.vars, prob.grid, prob.sol
-  @. vars.zetah = sol
+  
+  @. vars.ζh = sol
   @. vars.uh =   im * grid.l  * grid.invKrsq * sol
   @. vars.vh = - im * grid.kr * grid.invKrsq * sol
-  ldiv!(vars.zeta, grid.rfftplan, deepcopy(vars.zetah))
+  
+  ldiv!(vars.ζ, grid.rfftplan, deepcopy(vars.ζh))
   ldiv!(vars.u, grid.rfftplan, deepcopy(vars.uh))
   ldiv!(vars.v, grid.rfftplan, deepcopy(vars.vh))
+  
   return nothing
 end
 
 """
-    set_zeta!(prob, zeta)
+    set_ζ!(prob, ζ)
 
-Set the solution `sol` as the transform of `zeta` and update variables.
+Set the solution `sol` as the transform of `ζ` and then update variables in `vars`.
 """
-function set_zeta!(prob, zeta)
-  mul!(prob.sol, prob.grid.rfftplan, zeta)
+function set_ζ!(prob, ζ)
+  mul!(prob.sol, prob.grid.rfftplan, ζ)
   CUDA.@allowscalar prob.sol[1, 1] = 0 # zero domain average
   
   updatevars!(prob)
@@ -243,10 +284,15 @@ function set_zeta!(prob, zeta)
   return nothing
 end
 
+# = \\sum_{𝐤} \\frac1{2} |𝐤|^2 |ψ̂|^2 .
+
 """
     energy(prob)
 
-Returns the domain-averaged kinetic energy, ∫ ½(u²+v²)dxdy / (Lx Ly), for the solution in `sol`.
+Returns the domain-averaged kinetic energy,
+```math
+\\int \\frac1{2} (u² + v²) \\frac{𝖽x 𝖽y}{L_x L_y} = \\int \\frac1{2} |{\\bf ∇} ψ|² \\frac{𝖽x 𝖽y}{L_x L_y} = \\sum_{𝐤} \\frac1{2} |𝐤|² |ψ̂|² .
+```
 """
 @inline function energy(prob)
   sol, vars, grid = prob.sol, prob.vars, prob.grid
@@ -259,7 +305,10 @@ end
 """
     enstrophy(prob)
 
-Returns the domain-averaged enstrophy, ∫ ½ ζ² dxdy / (Lx Ly), for the solution in `sol`.
+Returns the domain-averaged enstrophy,
+```math
+\\int \\frac1{2} ζ² \\frac{𝖽x 𝖽y}{L_x L_y} = \\sum_{𝐤} \\frac1{2} |ζ̂|² .
+```
 """
 @inline function enstrophy(prob)
   sol, grid = prob.sol, prob.grid
@@ -269,13 +318,16 @@ end
 """
     energy_dissipation(prob)
 
-Returns the domain-averaged energy dissipation rate. `nν` must be >= 1.
+Returns the domain-averaged energy dissipation rate done by the ``ν`` viscous term,
+```math
+- ν (-1)^{n_ν+1} \\int ψ ∇^{2 n_ν}ζ \\frac{𝖽x 𝖽y}{L_x L_y} = - ν \\sum_{𝐤} |𝐤|^{2(n_ν-1)} |ζ̂|² .
+```
 """
 @inline function energy_dissipation(prob)
   sol, vars, params, grid = prob.sol, prob.vars, prob.params, prob.grid
   energy_dissipationh = vars.uh # use vars.uh as scratch variable
   
-  @. energy_dissipationh = params.ν * grid.Krsq^(params.nν - 1) * abs2(sol)
+  @. energy_dissipationh = - params.ν * grid.Krsq^(params.nν - 1) * abs2(sol)
   CUDA.@allowscalar energy_dissipationh[1, 1] = 0
   return 1 / (grid.Lx * grid.Ly) * parsevalsum(energy_dissipationh, grid)
 end
@@ -283,22 +335,65 @@ end
 """
     enstrophy_dissipation(prob)
 
-Returns the domain-averaged enstrophy dissipation rate. `nν` must be >= 1.
+Returns the domain-averaged enstrophy dissipation rate done by the ``ν`` viscous term,
+```math
+ν (-1)^{n_ν+1} \\int ζ ∇^{2 n_ν}ζ \\frac{𝖽x 𝖽y}{L_x L_y} = - ν \\sum_{𝐤} |𝐤|^{2n_ν} |ζ̂|² .
+```
 """
 @inline function enstrophy_dissipation(prob)
   sol, vars, params, grid = prob.sol, prob.vars, prob.params, prob.grid
   enstrophy_dissipationh = vars.uh # use vars.uh as scratch variable
   
-  @. enstrophy_dissipationh = params.ν * grid.Krsq^params.nν * abs2(sol)
+  @. enstrophy_dissipationh = - params.ν * grid.Krsq^params.nν * abs2(sol)
   CUDA.@allowscalar enstrophy_dissipationh[1, 1] = 0
   return 1 / (grid.Lx * grid.Ly) * parsevalsum(enstrophy_dissipationh, grid)
+end
+
+"""
+    energy_drag(prob)
+
+Returns the extraction of domain-averaged energy done by the ``μ`` viscous term,
+```math
+- μ (-1)^{n_μ+1} \\int ψ ∇^{2 n_μ}ζ \\frac{𝖽x 𝖽y}{L_x L_y} = - ν \\sum_{𝐤} |𝐤|^{2(n_μ-1)} |ζ̂|² .
+```
+"""
+@inline function energy_drag(prob)
+  sol, vars, params, grid = prob.sol, prob.vars, prob.params, prob.grid
+  
+  energy_dragh = vars.uh # use vars.uh as scratch variable
+  
+  @. energy_dragh = - params.μ * grid.Krsq^(params.nμ - 1) * abs2(sol)
+  CUDA.@allowscalar energy_dragh[1, 1] = 0
+  
+  return 1 / (grid.Lx * grid.Ly) * parsevalsum(energy_dragh, grid)
+end
+
+"""
+    enstrophy_drag(prob)
+
+Returns the extraction of domain-averaged enstrophy by the ``μ`` viscous term,
+```math
+μ (-1)^{n_μ+1} \\int ζ ∇^{2 n_μ}ζ \\frac{𝖽x 𝖽y}{L_x L_y} = - μ \\sum_{𝐤} |𝐤|^{2n_μ} |ζ̂|² .
+```
+"""
+@inline function enstrophy_drag(prob)
+  sol, vars, params, grid = prob.sol, prob.vars, prob.params, prob.grid
+
+  enstrophy_dragh = vars.uh # use vars.uh as scratch variable
+  
+  @. enstrophy_dragh = - params.μ * grid.Krsq^params.nμ * abs2(sol)
+  CUDA.@allowscalar enstrophy_dragh[1, 1] = 0
+  return 1 / (grid.Lx * grid.Ly) * parsevalsum(enstrophy_dragh, grid)
 end
 
 """
     energy_work(prob)
     energy_work(sol, vars, grid)
 
-Returns the domain-averaged rate of work of energy by the forcing `Fh`.
+Returns the domain-averaged rate of work of energy by the forcing ``F``,
+```math
+- \\int ψ F \\frac{𝖽x 𝖽y}{L_x L_y} = - \\sum_{𝐤} ψ̂ F̂^* .
+```
 """
 @inline function energy_work(sol, vars::ForcedVars, grid)
   energy_workh = vars.uh # use vars.uh as scratch variable
@@ -321,7 +416,10 @@ end
     enstrophy_work(prob)
     enstrophy_work(sol, vars, grid)
 
-Returns the domain-averaged rate of work of enstrophy by the forcing `Fh`.
+Returns the domain-averaged rate of work of enstrophy by the forcing ``F``,
+```math
+\\int ζ F \\frac{𝖽x 𝖽y}{L_x L_y} = \\sum_{𝐤} ζ̂ F̂^* .
+```
 """
 @inline function enstrophy_work(sol, vars::ForcedVars, grid)
   enstrophy_workh = vars.uh # use vars.uh as scratch variable
@@ -339,36 +437,5 @@ end
 end
 
 @inline enstrophy_work(prob) = enstrophy_work(prob.sol, prob.vars, prob.grid)
-
-"""
-    energy_drag(prob)
-
-Returns the extraction of domain-averaged energy by drag/hypodrag μ.
-"""
-@inline function energy_drag(prob)
-  sol, vars, params, grid = prob.sol, prob.vars, prob.params, prob.grid
-  
-  energy_dragh = vars.uh # use vars.uh as scratch variable
-  
-  @. energy_dragh = params.μ * grid.Krsq^(params.nμ - 1) * abs2(sol)
-  CUDA.@allowscalar energy_dragh[1, 1] = 0
-  
-  return 1 / (grid.Lx * grid.Ly) * parsevalsum(energy_dragh, grid)
-end
-
-"""
-    enstrophy_drag(prob)
-
-Returns the extraction of domain-averaged enstrophy by drag/hypodrag μ.
-"""
-@inline function enstrophy_drag(prob)
-  sol, vars, params, grid = prob.sol, prob.vars, prob.params, prob.grid
-
-  enstrophy_dragh = vars.uh # use vars.uh as scratch variable
-  
-  @. enstrophy_dragh = params.μ * grid.Krsq^params.nμ * abs2(sol)
-  CUDA.@allowscalar enstrophy_dragh[1, 1] = 0
-  return 1 / (grid.Lx * grid.Ly) * parsevalsum(enstrophy_dragh, grid)
-end
 
 end # module

--- a/src/twodnavierstokes.jl
+++ b/src/twodnavierstokes.jl
@@ -79,7 +79,7 @@ struct Params{T} <: AbstractParams
     "(hypo)-viscosity order, `nν ≤ 0`"
       nμ :: Int
     "function that calculates the forcing F̂"
-   calcF :: Function  # function that calculates the forcing F̂
+  calcF! :: Function  # function that calculates the forcing F̂
 end
 
 

--- a/src/twodnavierstokes.jl
+++ b/src/twodnavierstokes.jl
@@ -65,19 +65,22 @@ end
 # ----------
 
 """
-    Params(ν, nν, μ, nμ, calcF!)
+    Params{T}(ν, nν, μ, nμ, calcF!)
 
 Returns the params for two-dimensional Navier-Stokes.
 """
 struct Params{T} <: AbstractParams
-       ν :: T         # Viscosity
-      nν :: Int       # Hyperviscous order
-       μ :: T         # Hypoviscosity
-      nμ :: Int       # Hypoviscosity order
-  calcF! :: Function  # Function that calculates the forcing F̂
+    "small-scale (hyper)-viscosity coefficient"
+       ν :: T
+    "(hyper)-viscosity order, `nν ≥ 1`"
+      nν :: Int
+    "large-scale (hypo)-viscosity coefficient"
+       μ :: T
+    "(hypo)-viscosity order, `nν ≤ 0`"
+      nμ :: Int
+    "function that calculates the forcing F̂"
+   calcF :: Function  # function that calculates the forcing F̂
 end
-
-Params(ν, nν) = Params(ν, nν, typeof(ν)(0), 0, nothingfunction)
 
 
 # ---------
@@ -112,14 +115,27 @@ end
 
 abstract type TwoDNavierStokesVars <: AbstractVars end
 
+"""
+    Vars{Aphys, Atrans, F, P}(ζ, u, v, ζh, uh, vh, Fh, prevsol)
+
+Returns the vars for two-dimensional Navier-Stokes.
+"""
 struct Vars{Aphys, Atrans, F, P} <: TwoDNavierStokesVars
+    "relative vorticity"
         ζ :: Aphys
+    "x-component of velocity"
         u :: Aphys
+    "y-component of velocity"
         v :: Aphys
+    "Fourier transform of relative vorticity"
        ζh :: Atrans
+    "Fourier transform of x-component of velocity"
        uh :: Atrans
+    "Fourier transform of y-component of velocity"
        vh :: Atrans
+    "Fourier transform of forcing"
        Fh :: F
+    "`sol` at previous time-step"
   prevsol :: P
 end
 

--- a/src/twodnavierstokes.jl
+++ b/src/twodnavierstokes.jl
@@ -82,6 +82,8 @@ struct Params{T} <: AbstractParams
   calcF! :: Function  # function that calculates the forcing F̂
 end
 
+Params(ν, nν) = Params(ν, nν, typeof(ν)(0), 0, nothingfunction)
+
 
 # ---------
 # Equations

--- a/test/test_twodnavierstokes.jl
+++ b/test/test_twodnavierstokes.jl
@@ -1,20 +1,22 @@
 function test_twodnavierstokes_lambdipole(n, dt, dev::Device=CPU(); L=2π, Ue=1, Re=L/20, ν=0.0, nν=1, ti=L/Ue*0.01, nm=3)
   nt = round(Int, ti/dt)
   prob = TwoDNavierStokes.Problem(dev; nx=n, Lx=L, ν=ν, nν=nν, dt=dt, stepper="FilteredRK4")
-  zeta₀ = lambdipole(Ue, Re, prob.grid)
-  TwoDNavierStokes.set_zeta!(prob, zeta₀)
-
-  xzeta = zeros(nm) # centroid of abs(zeta)
-  Ue_m = zeros(nm)  # measured dipole speed
   x, y = gridpoints(prob.grid)
-  zeta = prob.vars.zeta
+  ζ = prob.vars.ζ
 
+  ζ₀ = lambdipole(Ue, Re, prob.grid)
+  TwoDNavierStokes.set_ζ!(prob, ζ₀)
+
+  xζ = zeros(nm)    # centroid of abs(ζ)
+  Ue_m = zeros(nm)  # measured dipole speed
+  
   for i = 1:nm # step forward
     stepforward!(prob, nt)
     TwoDNavierStokes.updatevars!(prob)
-    xzeta[i] = mean(@. abs(zeta)*x) / mean(abs.(zeta))
+    
+    xζ[i] = mean(@. abs(ζ) * x) / mean(abs.(ζ))
     if i > 1
-      Ue_m[i] = (xzeta[i]-xzeta[i-1]) / ((nt-1)*dt)
+      Ue_m[i] = (xζ[i] - xζ[i-1]) / ((nt-1)*dt)
     end
   end
   isapprox(Ue, mean(Ue_m[2:end]), rtol=rtol_lambdipole)
@@ -46,13 +48,14 @@ function test_twodnavierstokes_stochasticforcing_energybudget(dev::Device=CPU();
     eta = ArrayType(dev)(exp.(2π * im * rand(Float64, size(sol))) / sqrt(clock.dt))
     CUDA.@allowscalar eta[1, 1] = 0.0
     @. Fh = eta * sqrt(forcing_spectrum)
+    
     return nothing
   end
 
   prob = TwoDNavierStokes.Problem(dev; nx=n, Lx=L, ν=ν, nν=nν, μ=μ, nμ=nμ, dt=dt,
    stepper="RK4", calcF=calcF!, stochastic=true)
 
-  TwoDNavierStokes.set_zeta!(prob, 0*x)
+  TwoDNavierStokes.set_ζ!(prob, 0*x)
   
   E = Diagnostic(TwoDNavierStokes.energy,             prob, nsteps=nt)
   D = Diagnostic(TwoDNavierStokes.energy_dissipation, prob, nsteps=nt)
@@ -68,8 +71,8 @@ function test_twodnavierstokes_stochasticforcing_energybudget(dev::Device=CPU();
 
   # If the Ito interpretation was used for the work
   # then we need to add the drift term
-  # dEdt_computed = W[2:E.i] + ε - D[1:E.i-1] - R[1:E.i-1]      # Ito
-  dEdt_computed = W[2:E.i] - D[1:E.i-1] - R[1:E.i-1]        # Stratonovich
+  # dEdt_computed = W[2:E.i] + ε + D[1:E.i-1] + R[1:E.i-1]      # Ito
+  dEdt_computed = W[2:E.i] + D[1:E.i-1] + R[1:E.i-1]        # Stratonovich
 
   return isapprox(dEdt_numerical, dEdt_computed, rtol = 1e-3)
 end
@@ -100,13 +103,15 @@ function test_twodnavierstokes_stochasticforcing_enstrophybudget(dev::Device=CPU
     eta = ArrayType(dev)(exp.(2π * im * rand(Float64, size(sol))) / sqrt(cl.dt))
     CUDA.@allowscalar eta[1, 1] = 0.0
     @. Fh = eta * sqrt(forcing_spectrum)
+    
     nothing
   end
 
   prob = TwoDNavierStokes.Problem(dev; nx=n, Lx=L, ν=ν, nν=nν, μ=μ, nμ=nμ, dt=dt,
    stepper="RK4", calcF=calcF!, stochastic=true)
 
-  TwoDNavierStokes.set_zeta!(prob, 0*x)
+  TwoDNavierStokes.set_ζ!(prob, 0*x)
+  
   Z = Diagnostic(TwoDNavierStokes.enstrophy,             prob, nsteps=nt)
   D = Diagnostic(TwoDNavierStokes.enstrophy_dissipation, prob, nsteps=nt)
   R = Diagnostic(TwoDNavierStokes.enstrophy_drag,        prob, nsteps=nt)
@@ -121,8 +126,8 @@ function test_twodnavierstokes_stochasticforcing_enstrophybudget(dev::Device=CPU
 
   # If the Ito interpretation was used for the work
   # then we need to add the drift term
-  # dZdt_computed = W[2:Z.i] + εᶻ - D[1:Z.i-1] - R[1:Z.i-1]      # Ito
-  dZdt_computed = W[2:Z.i] - D[1:Z.i-1] - R[1:Z.i-1]        # Stratonovich
+  # dZdt_computed = W[2:Z.i] + εᶻ + D[1:Z.i-1] + R[1:Z.i-1]      # Ito
+  dZdt_computed = W[2:Z.i] + D[1:Z.i-1] + R[1:Z.i-1]        # Stratonovich
 
   return isapprox(dZdt_numerical, dZdt_computed, rtol = 1e-3)
 end
@@ -140,17 +145,19 @@ function test_twodnavierstokes_deterministicforcing_energybudget(dev::Device=CPU
   # Forcing = 0.01cos(4x)cos(5y)cos(2t)
   f = @. 0.01cos(4x) * cos(5y)
   fh = rfft(f)
+  
   function calcF!(Fh, sol, t, clock, vars, params, grid)
     @. Fh = fh * cos(2t)
+    
     return nothing
   end
 
   prob = TwoDNavierStokes.Problem(dev; nx=n, Lx=L, ν=ν, nν=nν, μ=μ, nμ=nμ, dt=dt,
    stepper="RK4", calcF=calcF!, stochastic=false)
 
-  TwoDNavierStokes.set_zeta!(prob, 0*x)
+  TwoDNavierStokes.set_ζ!(prob, 0*x)
 
-  E = Diagnostic(TwoDNavierStokes.energy,      prob, nsteps=nt)
+  E = Diagnostic(TwoDNavierStokes.energy,             prob, nsteps=nt)
   D = Diagnostic(TwoDNavierStokes.energy_dissipation, prob, nsteps=nt)
   R = Diagnostic(TwoDNavierStokes.energy_drag,        prob, nsteps=nt)
   W = Diagnostic(TwoDNavierStokes.energy_work,        prob, nsteps=nt)
@@ -161,7 +168,7 @@ function test_twodnavierstokes_deterministicforcing_energybudget(dev::Device=CPU
   TwoDNavierStokes.updatevars!(prob)
 
   dEdt_numerical = (E[3:E.i] - E[1:E.i-2]) / (2 * prob.clock.dt)
-  dEdt_computed  = W[2:E.i-1] - D[2:E.i-1] - R[2:E.i-1]
+  dEdt_computed  = W[2:E.i-1] + D[2:E.i-1] + R[2:E.i-1]
 
   return isapprox(dEdt_numerical, dEdt_computed, rtol = 1e-4)
 end
@@ -179,19 +186,19 @@ function test_twodnavierstokes_deterministicforcing_enstrophybudget(dev::Device=
   # Forcing = 0.01cos(4x)cos(5y)cos(2t)
   f = @. 0.01cos(4x) * cos(5y)
   fh = rfft(f)
+  
   function calcF!(Fh, sol, t, clock, vars, params, grid)
     @. Fh = fh * cos(2t)
+    
     return nothing
   end
 
   prob = TwoDNavierStokes.Problem(dev; nx=n, Lx=L, ν=ν, nν=nν, μ=μ, nμ=nμ, dt=dt,
    stepper="RK4", calcF=calcF!, stochastic=false)
 
-  sol, cl, v, p, g = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  TwoDNavierStokes.set_ζ!(prob, 0*x)
 
-  TwoDNavierStokes.set_zeta!(prob, 0*x)
-
-  Z = Diagnostic(TwoDNavierStokes.enstrophy,      prob, nsteps=nt)
+  Z = Diagnostic(TwoDNavierStokes.enstrophy,             prob, nsteps=nt)
   D = Diagnostic(TwoDNavierStokes.enstrophy_dissipation, prob, nsteps=nt)
   R = Diagnostic(TwoDNavierStokes.enstrophy_drag,        prob, nsteps=nt)
   W = Diagnostic(TwoDNavierStokes.enstrophy_work,        prob, nsteps=nt)
@@ -202,7 +209,7 @@ function test_twodnavierstokes_deterministicforcing_enstrophybudget(dev::Device=
   TwoDNavierStokes.updatevars!(prob)
 
   dZdt_numerical = (Z[3:Z.i] - Z[1:Z.i-2]) / (2 * prob.clock.dt)
-  dZdt_computed  = W[2:Z.i-1] - D[2:Z.i-1] - R[2:Z.i-1]
+  dZdt_computed  = W[2:Z.i-1] + D[2:Z.i-1] + R[2:Z.i-1]
 
   return isapprox(dZdt_numerical, dZdt_computed, rtol = 1e-4)
 end
@@ -228,8 +235,8 @@ function test_twodnavierstokes_advection(dt, stepper, dev::Device=CPU(); n=128, 
   grid = TwoDGrid(dev, n, L)
   x, y = gridpoints(grid)
 
-   psif = @.   sin(2x)*cos(2y) +  2sin(x)*cos(3y)
-  zetaf = @. -8sin(2x)*cos(2y) - 20sin(x)*cos(3y)
+  ψf = @.   sin(2x)*cos(2y) +  2sin(x)*cos(3y)
+  ζf = @. -8sin(2x)*cos(2y) - 20sin(x)*cos(3y)
 
   Ff = @. -(
     ν*( 64sin(2x)*cos(2y) + 200sin(x)*cos(3y) )
@@ -239,31 +246,33 @@ function test_twodnavierstokes_advection(dt, stepper, dev::Device=CPU(); n=128, 
   Ffh = rfft(Ff)
 
   # Forcing
-  function calcF!(Fh, sol, t, cl, v, p, g)
+  function calcF!(Fh, sol, t, clock, vars, params, grid)
     Fh .= Ffh
+    
     return nothing
   end
 
   prob = TwoDNavierStokes.Problem(dev; nx=n, Lx=L, ν=ν, nν=nν, μ=μ, nμ=nμ, dt=dt, stepper=stepper, calcF=calcF!, stochastic=false)
-  sol, cl, p, v, g = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
-  TwoDNavierStokes.set_zeta!(prob, zetaf)
+  
+  TwoDNavierStokes.set_ζ!(prob, ζf)
 
   stepforward!(prob, nt)
+  
   TwoDNavierStokes.updatevars!(prob)
 
-  isapprox(prob.vars.zeta, zetaf, rtol=rtol_twodnavierstokes)
+  isapprox(prob.vars.ζ, ζf, rtol=rtol_twodnavierstokes)
 end
 
 function test_twodnavierstokes_energyenstrophy(dev::Device=CPU())
   nx, Lx  = 128, 2π
-  ny, Ly  = 128, 3π
+  ny, Ly  = 126, 3π
   
   grid = TwoDGrid(dev, nx, Lx, ny, Ly)
   x, y = gridpoints(grid)
 
   k₀, l₀ = 2π/grid.Lx, 2π/grid.Ly # fundamental wavenumbers
-   ψ₀ = @. sin(2k₀*x)*cos(2l₀*y) + 2sin(k₀*x)*cos(3l₀*y)
-   ζ₀ = @. -((2k₀)^2+(2l₀)^2)*sin(2k₀*x)*cos(2l₀*y) - (k₀^2+(3l₀)^2)*2sin(k₀*x)*cos(3l₀*y)
+  ψ₀ = @. sin(2k₀*x)*cos(2l₀*y) + 2sin(k₀*x)*cos(3l₀*y)
+  ζ₀ = @. -((2k₀)^2+(2l₀)^2)*sin(2k₀*x)*cos(2l₀*y) - (k₀^2+(3l₀)^2)*2sin(k₀*x)*cos(3l₀*y)
 
   energy_calc = 29/9
   enstrophy_calc = 2701/162
@@ -272,7 +281,7 @@ function test_twodnavierstokes_energyenstrophy(dev::Device=CPU())
 
   sol, cl, v, p, g = prob.sol, prob.clock, prob.vars, prob.params, prob.grid;
 
-  TwoDNavierStokes.set_zeta!(prob, ζ₀)
+  TwoDNavierStokes.set_ζ!(prob, ζ₀)
   TwoDNavierStokes.updatevars!(prob)
 
   energyζ₀ = TwoDNavierStokes.energy(prob)

--- a/test/test_twodnavierstokes.jl
+++ b/test/test_twodnavierstokes.jl
@@ -57,10 +57,10 @@ function test_twodnavierstokes_stochasticforcing_energybudget(dev::Device=CPU();
 
   TwoDNavierStokes.set_ζ!(prob, 0*x)
   
-  E = Diagnostic(TwoDNavierStokes.energy,             prob, nsteps=nt)
-  D = Diagnostic(TwoDNavierStokes.energy_dissipation, prob, nsteps=nt)
-  R = Diagnostic(TwoDNavierStokes.energy_drag,        prob, nsteps=nt)
-  W = Diagnostic(TwoDNavierStokes.energy_work,        prob, nsteps=nt)
+  E = Diagnostic(TwoDNavierStokes.energy,                            prob, nsteps=nt)
+  D = Diagnostic(TwoDNavierStokes.energy_dissipation_hyperviscosity, prob, nsteps=nt)
+  R = Diagnostic(TwoDNavierStokes.energy_dissipation_hypoviscosity,  prob, nsteps=nt)
+  W = Diagnostic(TwoDNavierStokes.energy_work,                       prob, nsteps=nt)
   diags = [E, D, W, R]
 
   stepforward!(prob, diags, nt)
@@ -112,10 +112,10 @@ function test_twodnavierstokes_stochasticforcing_enstrophybudget(dev::Device=CPU
 
   TwoDNavierStokes.set_ζ!(prob, 0*x)
   
-  Z = Diagnostic(TwoDNavierStokes.enstrophy,             prob, nsteps=nt)
-  D = Diagnostic(TwoDNavierStokes.enstrophy_dissipation, prob, nsteps=nt)
-  R = Diagnostic(TwoDNavierStokes.enstrophy_drag,        prob, nsteps=nt)
-  W = Diagnostic(TwoDNavierStokes.enstrophy_work,        prob, nsteps=nt)
+  Z = Diagnostic(TwoDNavierStokes.enstrophy,                            prob, nsteps=nt)
+  D = Diagnostic(TwoDNavierStokes.enstrophy_dissipation_hyperviscosity, prob, nsteps=nt)
+  R = Diagnostic(TwoDNavierStokes.enstrophy_dissipation_hypoviscosity,  prob, nsteps=nt)
+  W = Diagnostic(TwoDNavierStokes.enstrophy_work,                       prob, nsteps=nt)
   diags = [Z, D, W, R]
 
   stepforward!(prob, diags, nt)
@@ -157,10 +157,10 @@ function test_twodnavierstokes_deterministicforcing_energybudget(dev::Device=CPU
 
   TwoDNavierStokes.set_ζ!(prob, 0*x)
 
-  E = Diagnostic(TwoDNavierStokes.energy,             prob, nsteps=nt)
-  D = Diagnostic(TwoDNavierStokes.energy_dissipation, prob, nsteps=nt)
-  R = Diagnostic(TwoDNavierStokes.energy_drag,        prob, nsteps=nt)
-  W = Diagnostic(TwoDNavierStokes.energy_work,        prob, nsteps=nt)
+  E = Diagnostic(TwoDNavierStokes.energy,                            prob, nsteps=nt)
+  D = Diagnostic(TwoDNavierStokes.energy_dissipation_hyperviscosity, prob, nsteps=nt)
+  R = Diagnostic(TwoDNavierStokes.energy_dissipation_hypoviscosity,  prob, nsteps=nt)
+  W = Diagnostic(TwoDNavierStokes.energy_work,                       prob, nsteps=nt)
   diags = [E, D, W, R]
 
   stepforward!(prob, diags, nt)
@@ -198,10 +198,10 @@ function test_twodnavierstokes_deterministicforcing_enstrophybudget(dev::Device=
 
   TwoDNavierStokes.set_ζ!(prob, 0*x)
 
-  Z = Diagnostic(TwoDNavierStokes.enstrophy,             prob, nsteps=nt)
-  D = Diagnostic(TwoDNavierStokes.enstrophy_dissipation, prob, nsteps=nt)
-  R = Diagnostic(TwoDNavierStokes.enstrophy_drag,        prob, nsteps=nt)
-  W = Diagnostic(TwoDNavierStokes.enstrophy_work,        prob, nsteps=nt)
+  Z = Diagnostic(TwoDNavierStokes.enstrophy,                            prob, nsteps=nt)
+  D = Diagnostic(TwoDNavierStokes.enstrophy_dissipation_hyperviscosity, prob, nsteps=nt)
+  R = Diagnostic(TwoDNavierStokes.enstrophy_dissipation_hypoviscosity,  prob, nsteps=nt)
+  W = Diagnostic(TwoDNavierStokes.enstrophy_work,                       prob, nsteps=nt)
   diags = [Z, D, W, R]
 
   stepforward!(prob, diags, nt)


### PR DESCRIPTION
This PR:

- uses unicode symbols for vorticity and stream-function
- enriches the docstrings and uses `@docs` refs in the Docs/TwoDNavierStokes module page
-  streamlines hyper/hypo viscosity sign convection (code + docs); closes #115
- removes boilerplate diagnostic, e.g., combines `energy_dissipation` and `energy_drag` and also the corresponding diagnostics for `enstrophy`

This PR introduces breaking changed and should come with the minor release.