### PR TITLE
Back to mp4 for Docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -9,3 +9,4 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 FourierFlows = "≥ 0.4.5"
+Plots = "≥ 1.10.1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,5 +8,5 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-FourierFlows = "≥ 0.4.5"
+FourierFlows = "≥ 0.6"
 Plots = "≥ 1.10.1"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -7,5 +7,5 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-FourierFlows = "≥ 0.4.5"
+FourierFlows = "≥ 0.6"
 Plots = "≥ 1.10.1"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -7,4 +7,5 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-FourierFlows = "≥ 0.4.4"
+FourierFlows = "≥ 0.4.5"
+Plots = "≥ 1.10.1"

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -280,7 +280,7 @@ anim = @animate for j = 0:round(Int, nsteps / nsubs)
   BarotropicQGQL.updatevars!(prob)
 end
 
-gif(anim, "barotropicqgql_betaforced.gif", fps=18)
+mp4(anim, "barotropicqgql_betaforced.mp4", fps=18)
 
 
 # ## Save

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -212,7 +212,7 @@ anim = @animate for j = 0:round(Int, nsteps / nsubs)
   MultiLayerQG.updatevars!(prob)
 end
 
-gif(anim, "multilayerqg_2layer.gif", fps=18)
+mp4(anim, "multilayerqg_2layer.mp4", fps=18)
 
 
 # ## Save

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -231,7 +231,7 @@ anim = @animate for j = 0:round(Int, nsteps/nsubs)
 
 end
 
-gif(anim, "barotropicqg_betadecay.gif", fps=8)
+mp4(anim, "barotropicqg_betadecay.mp4", fps=8)
 
 # ## Save
 

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -265,7 +265,7 @@ anim = @animate for j = 0:Int(nsteps / nsubs)
   SingleLayerQG.updatevars!(prob)
 end
 
-gif(anim, "barotropicqg_betaforced.gif", fps=18)
+mp4(anim, "barotropicqg_betaforced.mp4", fps=18)
 
 
 # ## Save

--- a/examples/singlelayerqg_decay_topography.jl
+++ b/examples/singlelayerqg_decay_topography.jl
@@ -231,4 +231,4 @@ anim = @animate for j = 0:round(Int, nsteps/nsubs)
   SingleLayerQG.updatevars!(prob)
 end
 
-gif(anim, "barotropicqg_decay_topography.gif", fps=12)
+mp4(anim, "barotropicqg_decay_topography.mp4", fps=12)

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -141,4 +141,4 @@ anim = @animate for j = 0:Int(nsteps/nsubs)
   SingleLayerQG.updatevars!(prob_eqbqg)
 end
 
-gif(anim, "singlelayerqg_barotropic_equivalentbarotropic.gif", fps=18)
+mp4(anim, "singlelayerqg_barotropic_equivalentbarotropic.mp4", fps=18)

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -195,7 +195,7 @@ anim = @animate for j = 0:round(Int, nsteps/nsubs)
   SurfaceQG.updatevars!(prob)
 end
 
-gif(anim, "sqg_ellipticalvortex.gif", fps=14)
+mp4(anim, "sqg_ellipticalvortex.mp4", fps=14)
 
 # Let's see how all flow fields look like at the end of the simulation.
 

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -159,7 +159,7 @@ anim = @animate for j = 0:Int(nsteps/nsubs)
   TwoDNavierStokes.updatevars!(prob)  
 end
 
-gif(anim, "twodturb.gif", fps=18)
+mp4(anim, "twodturb.mp4", fps=18)
 
 
 # Last we save the output.

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -175,4 +175,4 @@ anim = @animate for j = 0:round(Int, nsteps / nsubs)
   TwoDNavierStokes.updatevars!(prob)  
 end
 
-gif(anim, "twodturb_forced.gif", fps=18)
+mp4(anim, "twodturb_forced.mp4", fps=18)


### PR DESCRIPTION
This PR forces the Docs to use Plots v1.10.1 or later which includes the fix by @liasiegelman for allowing mp4 animations to be shown in Safari.

Closes #113.