### PR TITLE
Use FourierFlows.on_grid() functionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 CUDA = "^1, ^2"
 FFTW = "^1"
-FourierFlows = "^0.6"
+FourierFlows = "^0.6.10"
 JLD2 = "^0.1, ^0.2, ^0.3"
 Reexport = "^0.2, ^1"
 SpecialFunctions = "^0.10, ^1"

--- a/src/singlelayerqg.jl
+++ b/src/singlelayerqg.jl
@@ -60,7 +60,7 @@ function Problem(dev::Device=CPU();
   x, y = gridpoints(grid)
 
   # topographic PV
-  eta === nothing && ( eta = zeros(dev, T, (nx, ny)) )
+  eta === nothing && (eta = zeros(dev, T, (nx, ny)))
 
   params = deformation_radius == Inf ? BarotropicQGParams(grid, T(β), eta, T(μ), T(ν), nν, calcF) : EquivalentBarotropicQGParams(grid, T(β), T(deformation_radius), eta, T(μ), T(ν), nν, calcF)
 
@@ -97,15 +97,13 @@ end
 const BarotropicQGParams = Params{<:AbstractFloat, <:AbstractArray, <:AbstractArray, Nothing}
 const EquivalentBarotropicQGParams = Params{<:AbstractFloat, <:AbstractArray, <:AbstractArray, <:AbstractFloat}
 
-get_topographicPV_grid_values(eta::Function, grid::AbstractGrid{T, A}) where {T, A} = A([eta(grid.x[i], grid.y[j]) for i=1:grid.nx, j=1:grid.ny])
-
 """
     EquivalentBarotropicQGParams(grid::TwoDGrid, β, deformation_radius, eta, μ, ν, nν::Int, calcF
 
 Constructor for EquivalentBarotropicQGParams (finite Rossby radius of deformation).
 """
 function EquivalentBarotropicQGParams(grid::AbstractGrid{T, A}, β, deformation_radius, eta, μ, ν, nν::Int, calcF) where {T, A}
-  eta_grid = typeof(eta) <: AbstractArray ? eta : get_topographicPV_grid_values(eta, grid)
+  eta_grid = typeof(eta) <: AbstractArray ? eta : FourierFlows.on_grid(eta, grid)
   eta_gridh = rfft(eta_grid)
   return Params(β, deformation_radius, eta_grid, eta_gridh, μ, ν, nν, calcF)
 end
@@ -115,7 +113,7 @@ end
 
 Constructor for BarotropicQGParams (infinite Rossby radius of deformation).
 """
-BarotropicQGParams(grid::AbstractGrid{T, A}, β, eta, μ, ν, nν::Int, calcF) where {T, A} =
+BarotropicQGParams(grid::AbstractGrid, β, eta, μ, ν, nν::Int, calcF) =
     EquivalentBarotropicQGParams(grid, β, nothing, eta, μ, ν, nν, calcF)
     
 


### PR DESCRIPTION
This PR replaces the `get_topographicPV_grid_values()` function with `FourierFlows.on_grid()`.

Closes #170.