### PR TITLE
Examples run on GPU()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "GeophysicalFlows"
 uuid = "44ee3b1c-bc02-53fa-8355-8e347616e15e"
 license = "MIT"
 authors = ["Navid C. Constantinou <navidcy@gmail.com>", "Gregory L. Wagner <wagner.greg@gmail.com>"]
-version = "0.11.4"
+version = "0.11.5"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -21,7 +21,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 CUDA = "^1, ^2"
 DocStringExtensions = "^0.8"
 FFTW = "^1"
-FourierFlows = "^0.6.10"
+FourierFlows = "^0.6.12"
 JLD2 = "^0.1, ^0.2, ^0.3, ^0.4"
 Reexport = "^0.2, ^1"
 SpecialFunctions = "^0.10, ^1"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For more information, check out our [contributor's guide](https://github.com/Fou
 
 The code is citable via [zenodo](https://zenodo.org). Please cite as:
 
-> Navid C. Constantinou, Gregory L. Wagner, and co-contributors. (2021). FourierFlows/GeophysicalFlows.jl: GeophysicalFlows v0.11.4  (Version v0.11.4). Zenodo.  [http://doi.org/10.5281/zenodo.1463809](http://doi.org/10.5281/zenodo.1463809)
+> Navid C. Constantinou, Gregory L. Wagner, and co-contributors. (2021). FourierFlows/GeophysicalFlows.jl: GeophysicalFlows v0.11.5 (Version v0.11.5). Zenodo.  [http://doi.org/10.5281/zenodo.1463809](http://doi.org/10.5281/zenodo.1463809)
 
 
 [FourierFlows.jl]: https://github.com/FourierFlows/FourierFlows.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,5 +8,5 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-FourierFlows = "≥ 0.6"
+FourierFlows = "≥ 0.6.12"
 Plots = "≥ 1.10.1"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -7,5 +7,5 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-FourierFlows = "≥ 0.6.10"
+FourierFlows = "≥ 0.6.12"
 Plots = "≥ 1.10.1"

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -1,7 +1,6 @@
 # # Quasi-Linear forced-dissipative barotropic QG beta-plane turbulence
 #
-#md # This example can be run online via [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/barotropicqgql_betaforced.ipynb). 
-#md # Also, it can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/barotropicqgql_betaforced.ipynb).
+#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/barotropicqgql_betaforced.ipynb).
 #
 # A simulation of forced-dissipative barotropic quasi-geostrophic turbulence on 
 # a beta plane under the *quasi-linear approximation*. The dynamics include 
@@ -95,10 +94,12 @@ x, y = grid.x, grid.y
 nothing # hide
 
 
-# First let's see how a forcing realization looks like.
+# First let's see how a forcing realization looks like. Note that when plotting, we decorate 
+# the variable to be plotted with `Array()` to make sure it is brought back on the CPU when 
+# `vars` live on the GPU.
 calcF!(vars.Fh, sol, 0.0, clock, vars, params, grid)
 
-heatmap(x, y, irfft(vars.Fh, grid.nx)',
+heatmap(x, y, Array(irfft(vars.Fh, grid.nx)'),
      aspectratio = 1,
                c = :balance,
             clim = (-8, 8),

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -19,7 +19,7 @@ import GeophysicalFlows.BarotropicQGQL: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -19,7 +19,7 @@ import GeophysicalFlows.BarotropicQGQL: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -19,7 +19,7 @@ import GeophysicalFlows.BarotropicQGQL: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = GPU()     # Devvice (CPU/GPU)
 nothing # hide
 
 
@@ -286,6 +286,8 @@ mp4(anim, "barotropicqgql_betaforced.mp4", fps=18)
 
 # ## Save
 
-# Finally save the last snapshot.
-savename = @sprintf("%s_%09d.png", joinpath(plotpath, plotname), clock.step)
-savefig(savename)
+# Finally, we can save, e.g., the last snapshot via
+# ```julia
+# savename = @sprintf("%s_%09d.png", joinpath(plotpath, plotname), clock.step)
+# savefig(savename)
+# ```

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -65,7 +65,9 @@ forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2
 seed!(1234) # reset of the random number generator for reproducibility
 nothing # hide
 
-# Next we construct function `calcF!` that computes a forcing realization every timestep
+# Next we construct function `calcF!` that computes a forcing realization every timestep.
+# `ArrayType()` function returns the array type appropriate for the device, i.e., `Array` for
+# `dev = CPU()` and `CuArray` for `dev = GPU()`.
 function calcF!(Fh, sol, t, clock, vars, params, grid)
   ξ = exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt)
   

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows.MultiLayerQG: energies
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Devvice (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows.MultiLayerQG: energies
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = GPU()     # Devvice (CPU/GPU)
 nothing # hide
 
 
@@ -216,7 +216,8 @@ mp4(anim, "multilayerqg_2layer.mp4", fps=18)
 
 
 # ## Save
-
-# Finally save the last snapshot.
-savename = @sprintf("%s_%09d.png", joinpath(plotpath, plotname), clock.step)
-savefig(savename)
+# Finally, we can save, e.g., the last snapshot via
+# ```julia
+# savename = @sprintf("%s_%09d.png", joinpath(plotpath, plotname), clock.step)
+# savefig(savename)
+# ```

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows.MultiLayerQG: energies
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -61,6 +61,8 @@ nothing # hide
 
 # Our initial condition is some small amplitude random noise. We smooth our initial
 # condidtion using the `timestepper`'s high-wavenumber `filter`.
+# `ArrayType()` function returns the array type appropriate for the device, i.e., `Array` for
+# `dev = CPU()` and `CuArray` for `dev = GPU()`.
 
 seed!(1234) # reset of the random number generator for reproducibility
 q₀  = 4e-3 * ArrayType(dev)(randn((grid.nx, grid.ny, nlayers)))

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -63,11 +63,11 @@ nothing # hide
 # condidtion using the `timestepper`'s high-wavenumber `filter`.
 
 seed!(1234) # reset of the random number generator for reproducibility
-q_i  = 4e-3randn((grid.nx, grid.ny, nlayers))
-qh_i = prob.timestepper.filter .* rfft(q_i, (1, 2)) # only apply rfft in dims=1, 2
-q_i  = irfft(qh_i, grid.nx, (1, 2)) # only apply irfft in dims=1, 2
+q₀  = 4e-3 * ArrayType(dev)(randn((grid.nx, grid.ny, nlayers)))
+q₀h = prob.timestepper.filter .* rfft(q₀, (1, 2)) # only apply rfft in dims=1, 2
+q₀  = irfft(q₀h, grid.nx, (1, 2)) # only apply irfft in dims=1, 2
 
-MultiLayerQG.set_q!(prob, q_i)
+MultiLayerQG.set_q!(prob, q₀)
 nothing # hide
 
 

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -1,7 +1,6 @@
 # # Phillips model of Baroclinic Instability
 #
-#md # This example can be run online via [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/multilayerqg_2layer.ipynb).
-#md # Also, it can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/multilayerqg_2layer.ipynb).
+#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/multilayerqg_2layer.ipynb).
 #
 # A simulation of the growth of barolinic instability in the Phillips 2-layer model
 # when we impose a vertical mean flow shear as a difference ``\Delta U`` in the
@@ -113,8 +112,9 @@ nothing # hide
 
 # ## Visualizing the simulation
 
-# We define a function that plots the potential vorticity field and the evolution 
-# of energy and enstrophy.
+# We define a function that plots the potential vorticity field and the evolution of energy 
+# and enstrophy. Note that when plotting, we decorate the variable to be plotted with `Array()` 
+# to make sure it is brought back on the CPU when `vars` live on the GPU.
 
 symlims(data) = maximum(abs.(extrema(data))) |> q -> (-q, q)
 
@@ -125,7 +125,7 @@ function plot_output(prob)
   p = plot(layout=l, size = (1000, 600))
   
   for m in 1:nlayers
-    heatmap!(p[(m-1) * 3 + 1], x, y, vars.q[:, :, m]',
+    heatmap!(p[(m-1) * 3 + 1], x, y, Array(vars.q[:, :, m]'),
          aspectratio = 1,
               legend = false,
                    c = :balance,
@@ -139,7 +139,7 @@ function plot_output(prob)
                title = "q_"*string(m),
           framestyle = :box)
 
-    contourf!(p[(m-1) * 3 + 2], x, y, vars.ψ[:, :, m]',
+    contourf!(p[(m-1) * 3 + 2], x, y, Array(vars.ψ[:, :, m]'),
               levels = 8,
          aspectratio = 1,
               legend = false,
@@ -200,8 +200,8 @@ anim = @animate for j = 0:round(Int, nsteps / nsubs)
   end
   
   for m in 1:nlayers
-    p[(m-1) * 3 + 1][1][:z] = @. vars.q[:, :, m]
-    p[(m-1) * 3 + 2][1][:z] = @. vars.ψ[:, :, m]
+    p[(m-1) * 3 + 1][1][:z] = Array(vars.q[:, :, m])
+    p[(m-1) * 3 + 2][1][:z] = Array(vars.ψ[:, :, m])
   end
   
   push!(p[3][1], μ * E.t[E.i], E.data[E.i][1][1])

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows.MultiLayerQG: energies
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -57,17 +57,17 @@ nothing # hide
 E₀ = 0.1 # energy of initial condition
 
 K = @. sqrt(grid.Krsq)                          # a 2D array with the total wavenumber
-k = [grid.kr[i] for i=1:grid.nkr, j=1:grid.nl]  # a 2D array with the zonal wavenumber
+k = CUDA.@allowscalar ArrayType(dev)([grid.kr[i] for i=1:grid.nkr, j=1:grid.nl])   # a 2D array with the zonal wavenumber
 
 Random.seed!(1234)
-qih = randn(Complex{eltype(grid)}, size(sol))
-@. qih = ifelse(K < 2  * 2π/L, 0, qih)
-@. qih = ifelse(K > 10 * 2π/L, 0, qih)
-@. qih = ifelse(k == 0 * 2π/L, 0, qih)            # no power at zonal wavenumber k=0 component
-qih *= sqrt(E₀ / energy(qih, vars, params, grid)) # normalize qi to have energy E₀
-qi = irfft(qih, grid.nx)
+q₀h = ArrayType(dev)(randn(Complex{eltype(grid)}, size(sol)))
+@. q₀h = ifelse(K < 2  * 2π/L, 0, q₀h)
+@. q₀h = ifelse(K > 10 * 2π/L, 0, q₀h)
+@. q₀h = ifelse(k == 0 * 2π/L, 0, q₀h)            # no power at zonal wavenumber k=0 component
+q₀h *= sqrt(E₀ / energy(q₀h, vars, params, grid)) # normalize q₀ to have energy E₀
+q₀ = irfft(q₀h, grid.nx)
 
-SingleLayerQG.set_q!(prob, qi)
+SingleLayerQG.set_q!(prob, ArrayType(dev)(q₀))
 nothing # hide
 
 # Let's plot the initial vorticity and streamfunction. Note that when plotting, we decorate 

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -1,7 +1,6 @@
 # # Decaying barotropic QG beta-plane turbulence
 #
-#md # This example can be run online via [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/singlelayerqg_betadecay.ipynb). 
-#md # Also, it can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/singlelayerqg_betadecay.ipynb).
+#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/singlelayerqg_betadecay.ipynb).
 # 
 # An example of decaying barotropic quasi-geostrophic turbulence on a beta plane.
 
@@ -71,9 +70,11 @@ qi = irfft(qih, grid.nx)
 SingleLayerQG.set_q!(prob, qi)
 nothing # hide
 
-# Let's plot the initial vorticity field:
+# Let's plot the initial vorticity and streamfunction. Note that when plotting, we decorate 
+# the variable to be plotted with `Array()` to make sure it is brought back on the CPU when 
+# `vars` live on the GPU.
 
-p1 = heatmap(x, y, vars.q',
+p1 = heatmap(x, y, Array(vars.q'),
          aspectratio = 1,
               c = :balance,
            clim = (-12, 12),
@@ -86,7 +87,7 @@ p1 = heatmap(x, y, vars.q',
           title = "initial vorticity ∂v/∂x-∂u/∂y",
      framestyle = :box)
 
-p2 = contourf(x, y, vars.ψ',
+p2 = contourf(x, y, Array(vars.ψ'),
         aspectratio = 1,
              c = :viridis,
         levels = range(-0.65, stop=0.65, length=10), 
@@ -139,10 +140,10 @@ nothing # hide
 # their corresponding zonal mean structure.
 
 function plot_output(prob)
-  q = prob.vars.q
-  ψ = prob.vars.ψ
-  q̄ = mean(q, dims=1)'
-  ū = mean(prob.vars.u, dims=1)'
+  q = Array(prob.vars.q)
+  ψ = Array(prob.vars.ψ)
+  q̄ = Array(mean(q, dims=1)')
+  ū = Array(mean(prob.vars.u, dims=1)')
 
   pq = heatmap(x, y, q',
        aspectratio = 1,
@@ -220,11 +221,11 @@ anim = @animate for j = 0:round(Int, nsteps/nsubs)
     println(log)
   end  
 
-  p[1][1][:z] = vars.q
+  p[1][1][:z] = Array(vars.q)
   p[1][:title] = "vorticity, t="*@sprintf("%.2f", clock.t)
-  p[3][1][:z] = vars.ψ
-  p[2][1][:x] = mean(vars.q, dims=1)'
-  p[4][1][:x] = mean(vars.u, dims=1)'
+  p[3][1][:z] = Array(vars.ψ)
+  p[2][1][:x] = Array(mean(vars.q, dims=1)')
+  p[4][1][:x] = Array(mean(vars.u, dims=1)')
 
   stepforward!(prob, diags, nsubs)
   SingleLayerQG.updatevars!(prob)

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -52,7 +52,9 @@ nothing # hide
 # ## Setting initial conditions
 
 # Our initial condition consist of a flow that has power only at wavenumbers with
-# ``6 < \frac{L}{2\pi} \sqrt{k_x^2 + k_y^2} < 10`` and initial energy ``E_0``:
+# ``6 < \frac{L}{2\pi} \sqrt{k_x^2 + k_y^2} < 10`` and initial energy ``E_0``.
+# `ArrayType()` function returns the array type appropriate for the device, i.e., `Array` for
+# `dev = CPU()` and `CuArray` for `dev = GPU()`.
 
 E₀ = 0.08 # energy of initial condition
 

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -14,7 +14,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Devvice (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -14,7 +14,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -14,7 +14,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -64,7 +64,9 @@ forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2
 seed!(1234) # reset of the random number generator for reproducibility
 nothing # hide
 
-# Next we construct function `calcF!` that computes a forcing realization every timestep
+# Next we construct function `calcF!` that computes a forcing realization every timestep.
+# `ArrayType()` function returns the array type appropriate for the device, i.e., `Array` for
+# `dev = CPU()` and `CuArray` for `dev = GPU()`.
 function calcF!(Fh, sol, t, clock, vars, params, grid)
   ξ = exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt)
   

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -18,7 +18,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -5,7 +5,7 @@
 # A simulation of forced-dissipative barotropic quasi-geostrophic turbulence on 
 # a beta plane. The dynamics include linear drag and stochastic excitation.
 
-using FourierFlows, Plots, Statistics, Printf, Random, CUDA
+using FourierFlows, Plots, Statistics, Printf, Random
 
 using FourierFlows: parsevalsum
 using FFTW: irfft
@@ -18,7 +18,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Devvice (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 
@@ -59,7 +59,7 @@ K = @. sqrt(grid.Krsq)            # a 2D array with the total wavenumber
 
 forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2))
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
-@. forcing_spectrum *= ε/ε0               # normalize forcing to inject energy at rate ε
+@. forcing_spectrum *= ε/ε0       # normalize forcing to inject energy at rate ε
 
 seed!(1234) # reset of the random number generator for reproducibility
 nothing # hide
@@ -251,7 +251,7 @@ anim = @animate for j = 0:Int(nsteps / nsubs)
     println(log)
   end  
   
-  p[1a][1][:z] = Array(vars.q)
+  p[1][1][:z] = Array(vars.q)
   p[1][:title] = "vorticity, μt="*@sprintf("%.2f", μ * clock.t)
   p[4][1][:z] = Array(vars.ψ)
   p[2][1][:x] = Array(mean(vars.q, dims=1)')

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -1,7 +1,6 @@
 # # Forced-dissipative barotropic QG beta-plane turbulence
 #
-#md # This example can be run online via [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/singlelayerqg_betaforced.ipynb). 
-#md # Also, it can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/singlelayerqg_betaforced.ipynb).
+#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/singlelayerqg_betaforced.ipynb).
 #
 # A simulation of forced-dissipative barotropic quasi-geostrophic turbulence on 
 # a beta plane. The dynamics include linear drag and stochastic excitation.
@@ -94,10 +93,12 @@ x, y = grid.x, grid.y
 nothing # hide
 
 
-# First let's see how a forcing realization looks like.
+# First let's see how a forcing realization looks like. Note that when plotting, we decorate 
+# the variable to be plotted with `Array()` to make sure it is brought back on the CPU when 
+# `vars` live on the GPU.
 calcF!(vars.Fh, sol, 0.0, clock, vars, params, grid)
 
-heatmap(x, y, irfft(vars.Fh, grid.nx)',
+heatmap(x, y, Array(irfft(vars.Fh, grid.nx)'),
      aspectratio = 1,
                c = :balance,
             clim = (-8, 8),
@@ -158,7 +159,7 @@ function plot_output(prob)
   q̄ = mean(q, dims=1)'
   ū = mean(prob.vars.u, dims=1)'
   
-  pq = heatmap(x, y, q',
+  pq = heatmap(x, y, Arrat(q'),
        aspectratio = 1,
             legend = false,
                  c = :balance,
@@ -172,7 +173,7 @@ function plot_output(prob)
              title = "vorticity ∂v/∂x-∂u/∂y",
         framestyle = :box)
 
-  pψ = contourf(x, y, ψ',
+  pψ = contourf(x, y, Array(ψ'),
             levels = -0.32:0.04:0.32,
        aspectratio = 1,
          linewidth = 1,
@@ -188,7 +189,7 @@ function plot_output(prob)
              title = "streamfunction ψ",
         framestyle = :box)
 
-  pqm = plot(q̄, y,
+  pqm = plot(Array(q̄), y,
             legend = false,
          linewidth = 2,
              alpha = 0.7,
@@ -198,7 +199,7 @@ function plot_output(prob)
             ylabel = "y")
   plot!(pqm, 0*y, y, linestyle=:dash, linecolor=:black)
 
-  pum = plot(ū, y,
+  pum = plot(Array(ū), y,
             legend = false,
          linewidth = 2,
              alpha = 0.7,
@@ -253,11 +254,11 @@ anim = @animate for j = 0:Int(nsteps / nsubs)
     println(log)
   end  
   
-  p[1][1][:z] = vars.q
+  p[1][1][:z] = Array(vars.q)
   p[1][:title] = "vorticity, μt="*@sprintf("%.2f", μ * clock.t)
-  p[4][1][:z] = vars.ψ
-  p[2][1][:x] = mean(vars.q, dims=1)'
-  p[5][1][:x] = mean(vars.u, dims=1)'
+  p[4][1][:z] = Array(vars.ψ)
+  p[2][1][:x] = Array(mean(vars.q, dims=1)')
+  p[5][1][:x] = Array(mean(vars.u, dims=1)')
   push!(p[3][1], μ * E.t[E.i], E.data[E.i])
   push!(p[6][1], μ * Z.t[Z.i], Z.data[Z.i])
   

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -18,7 +18,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()    # Device (CPU/GPU)
+dev = GPU()    # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -18,7 +18,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_decay_topography.jl
+++ b/examples/singlelayerqg_decay_topography.jl
@@ -15,7 +15,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_decay_topography.jl
+++ b/examples/singlelayerqg_decay_topography.jl
@@ -15,7 +15,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Devvice (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_decay_topography.jl
+++ b/examples/singlelayerqg_decay_topography.jl
@@ -75,7 +75,9 @@ contourf(grid.x, grid.y, Array(params.eta'),
 # ## Setting initial conditions
 
 # Our initial condition consist of a flow that has power only at wavenumbers with
-# ``6 < \frac{L}{2\pi} \sqrt{k_x^2 + k_y^2} < 12`` and initial energy ``E_0``:
+# ``6 < \frac{L}{2\pi} \sqrt{k_x^2 + k_y^2} < 12`` and initial energy ``E_0``.
+# `ArrayType()` function returns the array type appropriate for the device, i.e., `Array` for
+# `dev = CPU()` and `CuArray` for `dev = GPU()`.
 
 E₀ = 0.04 # energy of initial condition
 

--- a/examples/singlelayerqg_decay_topography.jl
+++ b/examples/singlelayerqg_decay_topography.jl
@@ -15,7 +15,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = GPU()     # Devvice (CPU/GPU)
 nothing # hide
 
 
@@ -82,7 +82,7 @@ E₀ = 0.04 # energy of initial condition
 K = @. sqrt(grid.Krsq)                             # a 2D array with the total wavenumber
 
 Random.seed!(1234)
-qih = randn(Complex{eltype(grid)}, size(sol))
+qih = ArrayType(dev)(randn(Complex{eltype(grid)}, size(sol)))
 @. qih = ifelse(K < 6  * 2π/L, 0, qih)
 @. qih = ifelse(K > 12 * 2π/L, 0, qih)
 qih *= sqrt(E₀ / energy(qih, vars, params, grid))  # normalize qi to have energy E₀

--- a/examples/singlelayerqg_decay_topography.jl
+++ b/examples/singlelayerqg_decay_topography.jl
@@ -178,7 +178,7 @@ function plot_output(prob)
           levels=0.5:0.5:3,
           lw=2, c=:black, ls=:solid, alpha=0.7)
   
-  contour!(pq, x, y, η',
+  contour!(pq, x, y, Array(η'),
           levels=-2:0.5:-0.5,
           lw=2, c=:black, ls=:dash, alpha=0.7)
   

--- a/examples/singlelayerqg_decay_topography.jl
+++ b/examples/singlelayerqg_decay_topography.jl
@@ -1,7 +1,6 @@
 # # Decaying barotropic QG turbulence over topography
 #
-#md # This example can be run online via [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/singlelayerqg_decay_topography.ipynb). 
-#md # Also, it can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/singlelayerqg_decay_topography.ipynb).
+#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/singlelayerqg_decay_topography.ipynb).
 # 
 # An example of decaying barotropic quasi-geostrophic turbulence over topography.
 
@@ -55,8 +54,10 @@ sol, clock, vars, params, grid = prob.sol, prob.clock, prob.vars, prob.params, p
 x, y = grid.x, grid.y
 nothing # hide
 
-# and let's plot the topographic PV:
-contourf(grid.x, grid.y, params.eta',
+# and let's plot the topographic PV. Note that when plotting, we decorate the variable to be 
+# plotted with `Array()` to make sure it is brought back on the CPU when the variable lives 
+# on the GPU.
+contourf(grid.x, grid.y, Array(params.eta'),
           aspectratio = 1,
             linewidth = 0,
                levels = 10,
@@ -92,7 +93,7 @@ nothing # hide
 
 # Let's plot the initial vorticity field:
 
-p1 = heatmap(x, y, vars.q',
+p1 = heatmap(x, y, Array(vars.q'),
          aspectratio = 1,
               c = :balance,
            clim = (-8, 8),
@@ -105,7 +106,7 @@ p1 = heatmap(x, y, vars.q',
           title = "initial vorticity ∂v/∂x-∂u/∂y",
      framestyle = :box)
 
-p2 = contourf(x, y, vars.ψ',
+p2 = contourf(x, y, Array(vars.ψ'),
         aspectratio = 1,
              c = :viridis,
         levels = range(-0.25, stop=0.25, length=11), 
@@ -159,7 +160,7 @@ function plot_output(prob)
   ψ = prob.vars.ψ
   η = prob.params.eta
 
-  pq = heatmap(x, y, q',
+  pq = heatmap(x, y, Array(q'),
        aspectratio = 1,
             legend = false,
                  c = :balance,
@@ -173,7 +174,7 @@ function plot_output(prob)
              title = "vorticity ∂v/∂x-∂u/∂y",
         framestyle = :box)
   
-  contour!(pq, x, y, η',
+  contour!(pq, x, y, Array(η'),
           levels=0.5:0.5:3,
           lw=2, c=:black, ls=:solid, alpha=0.7)
   
@@ -181,7 +182,7 @@ function plot_output(prob)
           levels=-2:0.5:-0.5,
           lw=2, c=:black, ls=:dash, alpha=0.7)
   
-  pψ = contourf(x, y, ψ',
+  pψ = contourf(x, y, Array(ψ'),
        aspectratio = 1,
             legend = false,
                  c = :viridis,
@@ -223,9 +224,9 @@ anim = @animate for j = 0:round(Int, nsteps/nsubs)
     println(log)
   end  
 
-  p[1][1][:z] = vars.q
+  p[1][1][:z] = Array(vars.q)
   p[1][:title] = "vorticity, t="*@sprintf("%.2f", clock.t)
-  p[2][1][:z] = vars.ψ
+  p[2][1][:z] = Array(vars.ψ)
 
   stepforward!(prob, diags, nsubs)
   SingleLayerQG.updatevars!(prob)

--- a/examples/singlelayerqg_decay_topography.jl
+++ b/examples/singlelayerqg_decay_topography.jl
@@ -15,7 +15,7 @@ import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows: peakedisotropicspectrum
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Devvice (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows: peakedisotropicspectrum
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = GPU()     # Devvice (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows: peakedisotropicspectrum
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -1,7 +1,6 @@
 # # SingleLayerQG decaying 2D turbulence with and without finite Rossby radius of deformation
 #
-#md # This example can be run online via [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/singlelayerqg_decaying_barotropic_equivalentbarotropic.ipynb).
-#md # Also, it can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/singlelayerqg_decaying_barotropic_equivalentbarotropic.ipynb).
+#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/singlelayerqg_decaying_barotropic_equivalentbarotropic.ipynb).
 #
 # We use here the `SingleLayerQG` module to simulate decaying two-dimensional turbulence and
 # investigate how does a finite Rossby radius of deformation affects its evolution.
@@ -76,14 +75,14 @@ nothing # hide
 
 
 # Let's plot the initial vorticity field for each problem. A function that returns relative 
-# vorticity from each problem's state variable will prove useful. Since `relativevorticity()` 
-# is only used for plotting purposes, we call `collect()` at the end to bring its output on 
-# CPU in the case `vars` are on the GPU.
-relativevorticity(prob) = collect(irfft(-prob.grid.Krsq .* prob.vars.ψh, prob.grid.nx))
+# vorticity from each problem's state variable will prove useful. Note that when plotting, we 
+# decorate the variable to be plotted with `Array()` to make sure it is brought back on the 
+# CPU when the variable lives on the GPU.
+relativevorticity(prob) = irfft(-prob.grid.Krsq .* prob.vars.ψh, prob.grid.nx)
 
 x, y = prob_bqg.grid.x, prob_bqg.grid.y
 
-p_bqg = heatmap(x, y, relativevorticity(prob_bqg)',
+p_bqg = heatmap(x, y, Array(relativevorticity(prob_bqg)'),
          aspectratio = 1,
                    c = :balance,
                 clim = (-40, 40),
@@ -96,7 +95,7 @@ p_bqg = heatmap(x, y, relativevorticity(prob_bqg)',
                title = "barotropic\n ∇²ψ, t=" * @sprintf("%.2f", prob_bqg.clock.t),
           framestyle = :box)
 
-p_eqbqg = heatmap(x, y, relativevorticity(prob_eqbqg)',
+p_eqbqg = heatmap(x, y, Array(relativevorticity(prob_eqbqg)'),
          aspectratio = 1,
                    c = :balance,
                 clim = (-40, 40),

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows: peakedisotropicspectrum
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -131,9 +131,9 @@ anim = @animate for j = 0:Int(nsteps/nsubs)
     println(log_eqbqg)
   end  
 
-  p[1][1][:z] = relativevorticity(prob_bqg)
+  p[1][1][:z] = Array(relativevorticity(prob_bqg))
   p[1][:title] = "barotropic\n ∇²ψ, t=" * @sprintf("%.2f", prob_bqg.clock.t)
-  p[2][1][:z] = relativevorticity(prob_eqbqg)
+  p[2][1][:z] = Array(relativevorticity(prob_eqbqg))
   p[2][:title] = "equivalent barotropic; deformation radius: " * @sprintf("%.2f", prob_eqbqg.params.deformation_radius) * "\n ∇²ψ, t=" * @sprintf("%.2f", prob_eqbqg.clock.t)
   
   stepforward!(prob_bqg, nsubs)

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -19,7 +19,7 @@ import GeophysicalFlows.SurfaceQG: kinetic_energy, buoyancy_variance, buoyancy_d
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -19,7 +19,7 @@ import GeophysicalFlows.SurfaceQG: kinetic_energy, buoyancy_variance, buoyancy_d
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Devvice (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -19,7 +19,7 @@ import GeophysicalFlows.SurfaceQG: kinetic_energy, buoyancy_variance, buoyancy_d
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()    # Device (CPU/GPU)
+dev = GPU()    # Device (CPU/GPU)
 nothing # hide
 
 
@@ -65,8 +65,7 @@ SurfaceQG.set_b!(prob, b₀)
 nothing # hide
 
 # Let's plot the initial condition. Note that when plotting, we decorate the variable to be 
-# plotted with `Array()` to make sure the variable is brought back on the CPU when `vars` live 
-# on the GPU.
+# plotted with `Array()` to make sure it is brought back on the CPU when `vars` live on the GPU.
 heatmap(x, y, Array(vars.b'),
      aspectratio = 1,
                c = :deep,

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -19,7 +19,7 @@ import GeophysicalFlows.SurfaceQG: kinetic_energy, buoyancy_variance, buoyancy_d
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()    # Device (CPU/GPU)
+dev = GPU()     # Devvice (CPU/GPU)
 nothing # hide
 
 
@@ -241,4 +241,9 @@ layout = @layout [a{0.5h}; b{0.5w} c{0.5w}]
 
 plot_final = plot(pb, pu, pv, layout=layout, size = (800, 800))
 
-# Last we can save the output by calling `saveoutput(out)`.
+# ## Save
+
+# Last we can save the output by calling
+# ```julia
+# saveoutput(out)`
+# ```

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -64,8 +64,10 @@ b₀ = @. exp(-(X^2 + 4*Y^2))
 SurfaceQG.set_b!(prob, b₀)
 nothing # hide
 
-# Let's plot the initial condition.
-heatmap(x, y, prob.vars.b',
+# Let's plot the initial condition. Note that when plotting, we decorate the variable to be 
+# plotted with `Array()` to make sure the variable is brought back on the CPU when `vars` live 
+# on the GPU.
+heatmap(x, y, Array(vars.b'),
      aspectratio = 1,
                c = :deep,
             clim = (0, 1),
@@ -117,13 +119,13 @@ nothing # hide
 
 # ## Visualizing the simulation
 
-# We define a function that plots the buoyancy field and the time evolution of
-# kinetic energy and buoyancy variance.
+# We define a function that plots the buoyancy field and the time evolution of kinetic energy 
+# and buoyancy variance.
 
 function plot_output(prob)
   b = prob.vars.b
 
-  pb = heatmap(x, y, b',
+  pb = heatmap(x, y, Array(b'),
        aspectratio = 1,
                  c = :deep,
               clim = (0, 1),
@@ -184,7 +186,7 @@ anim = @animate for j = 0:round(Int, nsteps/nsubs)
     println(log2)
   end
 
-  p[1][1][:z] = vars.b
+  p[1][1][:z] = Array(vars.b)
   p[1][:title] = "buoyancy, t=" * @sprintf("%.2f", clock.t)
   push!(p[2][1], KE.t[KE.i], KE.data[KE.i])
   push!(p[3][1], B.t[B.i], B.data[B.i])
@@ -197,7 +199,7 @@ mp4(anim, "sqg_ellipticalvortex.mp4", fps=14)
 
 # Let's see how all flow fields look like at the end of the simulation.
 
-pu = heatmap(x, y, vars.u',
+pu = heatmap(x, y, Array(vars.u'),
      aspectratio = 1,
                c = :balance,
             clim = (-maximum(abs.(vars.u)), maximum(abs.(vars.u))),
@@ -210,7 +212,7 @@ pu = heatmap(x, y, vars.u',
            title = "uₛ(x, y, t=" * @sprintf("%.2f", clock.t) * ")",
       framestyle = :box)
 
-pv = heatmap(x, y, vars.v',
+pv = heatmap(x, y, Array(vars.v'),
      aspectratio = 1,
                c = :balance,
             clim = (-maximum(abs.(vars.v)), maximum(abs.(vars.v))),
@@ -223,7 +225,7 @@ pv = heatmap(x, y, vars.v',
            title = "vₛ(x, y, t=" * @sprintf("%.2f", clock.t) * ")",
       framestyle = :box)
 
-pb = heatmap(x, y, vars.b',
+pb = heatmap(x, y, Array(vars.b'),
      aspectratio = 1,
                c = :deep,
             clim = (0, 1),

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -19,7 +19,7 @@ import GeophysicalFlows.SurfaceQG: kinetic_energy, buoyancy_variance, buoyancy_d
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows: peakedisotropicspectrum
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Devvice (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 
@@ -48,8 +48,7 @@ nothing # hide
 
 # ## Setting initial conditions
 
-# Our initial condition closely tries to reproduce the initial condition used
-# in the paper by McWilliams (_JFM_, 1984)
+# Our initial condition tries to reproduce the initial condition used by McWilliams (_JFM_, 1984).
 seed!(1234)
 k₀, E₀ = 6, 0.5
 ζ₀ = peakedisotropicspectrum(grid, k₀, E₀, mask=prob.timestepper.filter)

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows: peakedisotropicspectrum
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = GPU()     # Devvice (CPU/GPU)
 nothing # hide
 
 
@@ -27,7 +27,7 @@ nothing # hide
 n, L  = 128, 2π             # grid resolution and domain length
 nothing # hide
 
-## Then we pick the time-stepper parameters
+# Then we pick the time-stepper parameters
     dt = 1e-2  # timestep
 nsteps = 4000  # total number of steps
  nsubs = 20    # number of steps between each plot
@@ -163,8 +163,10 @@ end
 mp4(anim, "twodturb.mp4", fps=18)
 
 
-# Last we save the output.
-saveoutput(out)
+# Last we can save the output by calling
+# ```julia
+# saveoutput(out)`
+# ```
 
 
 # ## Radial energy spectrum

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -1,7 +1,6 @@
 # # 2D decaying turbulence
 #
-#md # This example can be run online via [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/twodnavierstokes_decaying.ipynb).
-#md # Also, it can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/twodnavierstokes_decaying.ipynb).
+#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/twodnavierstokes_decaying.ipynb).
 #
 # A simulation of decaying two-dimensional turbulence.
 
@@ -57,8 +56,10 @@ k₀, E₀ = 6, 0.5
 TwoDNavierStokes.set_ζ!(prob, ζ₀)
 nothing # hide
 
-# Let's plot the initial vorticity field:
-heatmap(x, y, vars.ζ',
+# Let's plot the initial vorticity field. Note that when plotting, we decorate the variable 
+# to be plotted with `Array()` to make sure it is brought back on the CPU when `vars` live on 
+# the GPU.
+heatmap(x, y, Array(vars.ζ'),
          aspectratio = 1,
               c = :balance,
            clim = (-40, 40),
@@ -108,7 +109,7 @@ nothing # hide
 # We initialize a plot with the vorticity field and the time-series of
 # energy and enstrophy diagnostics.
 
-p1 = heatmap(x, y, vars.ζ',
+p1 = heatmap(x, y, Array(vars.ζ'),
          aspectratio = 1,
                    c = :balance,
                 clim = (-40, 40),
@@ -150,7 +151,7 @@ anim = @animate for j = 0:Int(nsteps/nsubs)
     println(log)
   end  
 
-  p[1][1][:z] = vars.ζ
+  p[1][1][:z] = Array(vars.ζ)
   p[1][:title] = "vorticity, t=" * @sprintf("%.2f", clock.t)
   push!(p[2][1], E.t[E.i], E.data[E.i]/E.data[1])
   push!(p[2][2], Z.t[Z.i], Z.data[Z.i]/Z.data[1])

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows: peakedisotropicspectrum
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -16,7 +16,7 @@ import GeophysicalFlows: peakedisotropicspectrum
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -18,7 +18,7 @@ import GeophysicalFlows.TwoDNavierStokes: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -18,7 +18,7 @@ import GeophysicalFlows.TwoDNavierStokes: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 
@@ -40,7 +40,7 @@ nothing # hide
 # We force the vorticity equation with stochastic excitation that is delta-correlated
 # in time and while spatially homogeneously and isotropically correlated. The forcing
 # has a spectrum with power in a ring in wavenumber space of radius ``k_f`` (`forcing_wavenumber`) and width 
-# ``\delta k_f`` (`forcing_bandwidth`), and it injects energy per unit area and perr unit time 
+# ``\delta k_f`` (`forcing_bandwidth`), and it injects energy per unit area and per unit time 
 # equal to ``\varepsilon``. That is, the forcing covariance spectrum is proportional to 
 # ``\exp{(-(|\bm{k}| - k_f)^2 / (2 \delta k_f^2))}``.
 
@@ -54,7 +54,7 @@ K = @. sqrt(grid.Krsq)             # a 2D array with the total wavenumber
 
 forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2))
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
-@. forcing_spectrum *= ε/ε0               # normalize forcing to inject energy at rate ε
+@. forcing_spectrum *= ε/ε0        # normalize forcing to inject energy at rate ε
 
 seed!(1234)
 nothing # hide

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -59,7 +59,9 @@ forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2
 seed!(1234)
 nothing # hide
 
-# Next we construct function `calcF!` that computes a forcing realization every timestep
+# Next we construct function `calcF!` that computes a forcing realization every timestep.
+# `ArrayType()` function returns the array type appropriate for the device, i.e., `Array` for
+# `dev = CPU()` and `CuArray` for `dev = GPU()`.
 function calcF!(Fh, sol, t, clock, vars, params, grid)
   ξ = exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt)
   ξ[1, 1] = 0

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -18,7 +18,7 @@ import GeophysicalFlows.TwoDNavierStokes: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -6,7 +6,7 @@
 # two-dimensional vorticity equation with stochastic excitation and dissipation in
 # the form of linear drag and hyperviscosity. 
 
-using FourierFlows, Printf, Plots
+using FourierFlows, Printf, Plot
 
 using FourierFlows: parsevalsum
 using Random: seed!
@@ -61,9 +61,10 @@ nothing # hide
 
 # Next we construct function `calcF!` that computes a forcing realization every timestep
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  ξ = ArrayType(dev)(exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt))
+  ξ = exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt)
   ξ[1, 1] = 0
-  @. Fh = ξ * sqrt(forcing_spectrum)
+  
+  Fh .= ArrayType(dev)(ξ) .* sqrt.(forcing_spectrum)
   
   return nothing
 end
@@ -109,7 +110,7 @@ heatmap(x, y, Array(irfft(vars.Fh, grid.nx)'),
 # ## Setting initial conditions
 
 # Our initial condition is a fluid at rest.
-TwoDNavierStokes.set_ζ!(prob, zeros(grid.nx, grid.ny))
+TwoDNavierStokes.set_ζ!(prob, ArrayType(dev)(zeros(grid.nx, grid.ny)))
 
 
 # ## Diagnostics

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -6,7 +6,7 @@
 # two-dimensional vorticity equation with stochastic excitation and dissipation in
 # the form of linear drag and hyperviscosity. 
 
-using FourierFlows, Printf, Plot
+using FourierFlows, Printf, Plots
 
 using FourierFlows: parsevalsum
 using Random: seed!
@@ -18,7 +18,7 @@ import GeophysicalFlows.TwoDNavierStokes: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()    # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 
@@ -39,9 +39,10 @@ nothing # hide
 
 # We force the vorticity equation with stochastic excitation that is delta-correlated
 # in time and while spatially homogeneously and isotropically correlated. The forcing
-# has a spectrum with power in a ring in wavenumber space of radius ``k_f`` and
-# width ``\delta k_f``, and it injects energy per unit area and per unit time equal
-# to ``\varepsilon``.
+# has a spectrum with power in a ring in wavenumber space of radius ``k_f`` (`forcing_wavenumber`) and width 
+# ``\delta k_f`` (`forcing_bandwidth`), and it injects energy per unit area and perr unit time 
+# equal to ``\varepsilon``. That is, the forcing covariance spectrum is proportional to 
+# ``\exp{(-(|\bm{k}| - k_f)^2 / (2 \delta k_f^2))}``.
 
 forcing_wavenumber = 14.0 * 2π/L   # the central forcing wavenumber for a spectrum that is a ring in wavenumber space
 forcing_bandwidth  = 1.5  * 2π/L   # the width of the forcing spectrum
@@ -49,12 +50,11 @@ forcing_bandwidth  = 1.5  * 2π/L   # the width of the forcing spectrum
 
 grid = TwoDGrid(dev, n, L)
 
-K = @. sqrt(grid.Krsq)
+K = @. sqrt(grid.Krsq)             # a 2D array with the total wavenumber
+
 forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2))
-@. forcing_spectrum = ifelse(K < 2  * 2π/L, 0, forcing_spectrum)      # no power at low wavenumbers
-@. forcing_spectrum = ifelse(K > 20 * 2π/L, 0, forcing_spectrum)      # no power at high wavenumbers
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
-@. forcing_spectrum *= ε / ε0             # normalize forcing to inject energy at rate ε
+@. forcing_spectrum *= ε/ε0               # normalize forcing to inject energy at rate ε
 
 seed!(1234)
 nothing # hide
@@ -128,7 +128,7 @@ nothing # hide
 # energy and enstrophy diagnostics. To plot energy and enstrophy on the same
 # axes we scale enstrophy with ``k_f^2``.
 
-p1 = heatmap(x, y, Array( vars.ζ'),
+p1 = heatmap(x, y, Array(vars.ζ'),
          aspectratio = 1,
                    c = :balance,
                 clim = (-40, 40),

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -18,7 +18,7 @@ import GeophysicalFlows.TwoDNavierStokes: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()    # Device (CPU/GPU)
+dev = GPU()    # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -1,7 +1,6 @@
 # # 2D forced-dissipative turbulence
 #
-#md # This example can be run online via [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/twodnavierstokes_stochasticforcing.ipynb).
-#md # Also, it can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/twodnavierstokes_stochasticforcing.ipynb).
+#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/twodnavierstokes_stochasticforcing.ipynb).
 #
 # A simulation of forced-dissipative two-dimensional turbulence. We solve the
 # two-dimensional vorticity equation with stochastic excitation and dissipation in
@@ -88,9 +87,12 @@ nothing # hide
 # First let's see how a forcing realization looks like. Function `calcF!()` computes 
 # the forcing in Fourier space and saves it into variable `vars.Fh`, so we first need to
 # go back to physical space.
+
+# Note that when plotting, we decorate the variable to be plotted with `Array()` to make sure 
+# it is brought back on the CPU when the variable lives on the GPU.
 calcF!(vars.Fh, sol, 0.0, clock, vars, params, grid)
 
-heatmap(x, y, irfft(vars.Fh, grid.nx)',
+heatmap(x, y, Array(irfft(vars.Fh, grid.nx)'),
      aspectratio = 1,
                c = :balance,
             clim = (-200, 200),
@@ -123,9 +125,9 @@ nothing # hide
 
 # We initialize a plot with the vorticity field and the time-series of
 # energy and enstrophy diagnostics. To plot energy and enstrophy on the same
-# axes we scale enstrophy with $k_f^2$.
+# axes we scale enstrophy with ``k_f^2``.
 
-p1 = heatmap(x, y, vars.ζ',
+p1 = heatmap(x, y, Array( vars.ζ'),
          aspectratio = 1,
                    c = :balance,
                 clim = (-40, 40),
@@ -166,7 +168,7 @@ anim = @animate for j = 0:round(Int, nsteps / nsubs)
     println(log)
   end  
 
-  p[1][1][:z] = vars.ζ
+  p[1][1][:z] = Array(vars.ζ)
   p[1][:title] = "vorticity, μt = " * @sprintf("%.2f", μ * clock.t)
   push!(p[2][1], μ * E.t[E.i], E.data[E.i])
   push!(p[2][2], μ * Z.t[Z.i], Z.data[Z.i] / forcing_wavenumber^2)

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -21,7 +21,7 @@ import GeophysicalFlows.TwoDNavierStokes: enstrophy, enstrophy_dissipation_hyper
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Devvice (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 
@@ -57,7 +57,7 @@ K = @. sqrt(grid.Krsq)             # a 2D array with the total wavenumber
 
 forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2))
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
-@. forcing_spectrum *= ε/ε0               # normalize forcing to inject energy at rate ε
+@. forcing_spectrum *= ε/ε0        # normalize forcing to inject energy at rate ε
 
 seed!(1234)
 nothing # hide

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -21,7 +21,7 @@ import GeophysicalFlows.TwoDNavierStokes: enstrophy, enstrophy_dissipation_hyper
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()     # Device (CPU/GPU)
+dev = CPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -1,7 +1,6 @@
 # # 2D forced-dissipative turbulence budgets
 #
-#md # This example can be run online via [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/twodnavierstokes_stochasticforcing_budgets.ipynb).
-#md # Also, it can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/twodnavierstokes_stochasticforcing_budgets.ipynb).
+#md # This example can viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/twodnavierstokes_stochasticforcing_budgets.ipynb).
 #
 # A simulation of forced-dissipative two-dimensional turbulence. We solve the
 # two-dimensional vorticity equation with stochastic excitation and dissipation in
@@ -91,10 +90,13 @@ nothing # hide
 
 # First let's see how a forcing realization looks like. Function `calcF!()` computes 
 # the forcing in Fourier space and saves it into variable `vars.Fh`, so we first need to
-# go back to physical space.
+# go back to physical space. 
+#
+# Note that when plotting, we decorate the variable to be plotted with `Array()` to make sure 
+# it is brought back on the CPU when the variable lives on the GPU.
 calcF!(vars.Fh, sol, 0.0, clock, vars, params, grid)
 
-heatmap(x, y, irfft(vars.Fh, grid.nx)',
+heatmap(x, y, Array(irfft(vars.Fh, grid.nx)'),
      aspectratio = 1,
                c = :balance,
             clim = (-200, 200),
@@ -157,7 +159,7 @@ function computetendencies_and_makeplot(prob, diags)
 
   εᶻ = parsevalsum(forcing_spectrum / 2, grid) / (grid.Lx * grid.Ly)
 
-  pζ = heatmap(x, y, vars.ζ',
+  pζ = heatmap(x, y, Array(vars.ζ'),
             aspectratio = 1,
             legend = false,
                  c = :viridis,

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -21,7 +21,7 @@ import GeophysicalFlows.TwoDNavierStokes: enstrophy, enstrophy_dissipation_hyper
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()    # Device (CPU/GPU)
+dev = GPU()    # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -65,9 +65,10 @@ nothing # hide
 
 # Next we construct function `calcF!` that computes a forcing realization every timestep
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  ξ = ArrayType(dev)(exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt))
+  ξ = exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt)
   ξ[1, 1] = 0
-  @. Fh = ξ * sqrt(forcing_spectrum)
+  
+  Fh .= ArrayType(dev)(ξ) .* sqrt.(forcing_spectrum)
   
   return nothing
 end
@@ -113,7 +114,7 @@ heatmap(x, y, Array(irfft(vars.Fh, grid.nx)'),
 # ## Setting initial conditions
 
 # Our initial condition is a fluid at rest.
-TwoDNavierStokes.set_ζ!(prob, zeros(grid.nx, grid.ny))
+TwoDNavierStokes.set_ζ!(prob, ArrayType(dev)(zeros(grid.nx, grid.ny)))
 
 
 # ## Diagnostics

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -21,7 +21,7 @@ import GeophysicalFlows.TwoDNavierStokes: enstrophy, enstrophy_dissipation_hyper
 
 # ## Choosing a device: CPU or GPU
 
-dev = CPU()     # Device (CPU/GPU)
+dev = GPU()     # Device (CPU/GPU)
 nothing # hide
 
 

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -21,7 +21,7 @@ import GeophysicalFlows.TwoDNavierStokes: enstrophy, enstrophy_dissipation_hyper
 
 # ## Choosing a device: CPU or GPU
 
-dev = GPU()    # Device (CPU/GPU)
+dev = GPU()     # Devvice (CPU/GPU)
 nothing # hide
 
 
@@ -40,11 +40,12 @@ nothing # hide
 
 # ## Forcing
 
-# We force the vorticity equation with stochastic excitation that is delta-correlated
-# in time and while spatially homogeneously and isotropically correlated. The forcing
-# has a spectrum with power in a ring in wavenumber space of radius ``k_f`` and
-# width ``\delta k_f``, and it injects energy per unit area and per unit time equal
-# to ``\varepsilon``.
+# We force the vorticity equation with stochastic excitation that is delta-correlated in time 
+# and while spatially homogeneously and isotropically correlated. The forcing has a spectrum 
+# with power in a ring in wavenumber space of radius ``k_f`` (`forcing_wavenumber`) and width 
+# ``\delta k_f`` (`forcing_bandwidth`), and it injects energy per unit area and per unit time 
+# equal to ``\varepsilon``. That is, the forcing covariance spectrum is proportional to 
+# ``\exp{(-(|\bm{k}| - k_f)^2 / (2 \delta k_f^2))}``.
 
 forcing_wavenumber = 14.0 * 2π/L   # the central forcing wavenumber for a spectrum that is a ring in wavenumber space
 forcing_bandwidth  = 1.5  * 2π/L   # the width of the forcing spectrum
@@ -52,13 +53,11 @@ forcing_bandwidth  = 1.5  * 2π/L   # the width of the forcing spectrum
 
 grid = TwoDGrid(dev, n, L)
 
-K = @. sqrt(grid.Krsq)
+K = @. sqrt(grid.Krsq)             # a 2D array with the total wavenumber
 
 forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2))
-@. forcing_spectrum = ifelse(K < 2  * 2π/L, 0, forcing_spectrum)      # no power at low wavenumbers
-@. forcing_spectrum = ifelse(K > 20 * 2π/L, 0, forcing_spectrum)      # no power at high wavenumbers
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
-@. forcing_spectrum *= ε/ε0             # normalize forcing to inject energy at rate ε
+@. forcing_spectrum *= ε/ε0               # normalize forcing to inject energy at rate ε
 
 seed!(1234)
 nothing # hide

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -62,7 +62,9 @@ forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2
 seed!(1234)
 nothing # hide
 
-# Next we construct function `calcF!` that computes a forcing realization every timestep
+# Next we construct function `calcF!` that computes a forcing realization every timestep.
+# `ArrayType()` function returns the type of array depending on the device, i.e., `Array` for
+# `dev = CPU()` and `CuArray` for `dev = GPU()`.
 function calcF!(Fh, sol, t, clock, vars, params, grid)
   ξ = exp.(2π * im * rand(eltype(grid), size(sol))) / sqrt(clock.dt)
   ξ[1, 1] = 0


### PR DESCRIPTION
This PR generalizes all examples so they run without any errors on GPUs.

it also removed all Binder links from examples since the size of gh-pages branch has rendered them unusable. 

Closes #167. Closes #203. 

Also addresses one of @ranocha's [review remarks](https://github.com/openjournals/joss-reviews/issues/3053#issuecomment-790762419).