### PR TITLE
Warning when user wants MultiLayerQG on the GPU

### DIFF
--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -59,6 +59,12 @@ function Problem(nlayers::Int,                        # number of fluid layers
                   linear = false,
                        T = Float64)
 
+   if dev == GPU()
+     @warn """MultiLayerQG module not well optimized on the GPU yet.
+     See https://github.com/FourierFlows/GeophysicalFlows.jl/issues/112
+     For now, we suggest running MultiLayerQG on CPUs only."""
+   end
+   
    # topographic PV
    eta === nothing && (eta = zeros(dev, T, (nx, ny)))
    

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -61,7 +61,7 @@ function Problem(nlayers::Int,                        # number of fluid layers
 
    if dev == GPU()
      @warn """MultiLayerQG module not well optimized on the GPU yet.
-     See https://github.com/FourierFlows/GeophysicalFlows.jl/issues/112
+     See issue on Github at https://github.com/FourierFlows/GeophysicalFlows.jl/issues/112.
      For now, we suggest running MultiLayerQG on CPUs only."""
    end
    


### PR DESCRIPTION
This PR adds a warning to the user when they try to construct a `MultiLayerQG` problem on the GPU explaining that the module is not well optimized on the GPU.

This warning should stay here until #112 is resolved.
