### PR TITLE
Enhance Module pages in Docs

### DIFF
--- a/docs/src/modules/barotropicqgql.md
+++ b/docs/src/modules/barotropicqgql.md
@@ -1,4 +1,4 @@
-# BarotropicQGQL Module
+# BarotropicQGQL
 
 ### Basic Equations
 
@@ -116,4 +116,8 @@ Other diagnostic include: [`dissipation`](@ref GeophysicalFlows.BarotropicQGQL.d
 
 ## Examples
 
-- `examples/barotropicqgql_betaforced.jl`: A script that simulates forced-dissipative quasi-linear quasi-geostrophic flow on a beta-plane demonstrating zonation. The forcing is temporally delta-correlated and its spatial structure is isotropic with power in a narrow annulus of total radius ``k_f`` in wavenumber space. This example demonstrates that the anisotropic inverse energy cascade is not required for zonation.
+- [`examples/barotropicqgql_betaforced.jl`](../generated/barotropicqgql_betaforced/): A script 
+  that simulates forced-dissipative quasi-linear quasi-geostrophic flow on a beta-plane demonstrating 
+	zonation. The forcing is temporally delta-correlated and its spatial structure is isotropic 
+	with power in a narrow annulus of total radius ``k_f`` in wavenumber space. This example 
+	demonstrates that the anisotropic inverse energy cascade is not required for zonation.

--- a/docs/src/modules/barotropicqgql.md
+++ b/docs/src/modules/barotropicqgql.md
@@ -116,8 +116,4 @@ Other diagnostic include: [`dissipation`](@ref GeophysicalFlows.BarotropicQGQL.d
 
 ## Examples
 
-- [`examples/barotropicqgql_betaforced.jl`](../generated/barotropicqgql_betaforced/): A script 
-  that simulates forced-dissipative quasi-linear quasi-geostrophic flow on a beta-plane demonstrating 
-	zonation. The forcing is temporally delta-correlated and its spatial structure is isotropic 
-	with power in a narrow annulus of total radius ``k_f`` in wavenumber space. This example 
-	demonstrates that the anisotropic inverse energy cascade is not required for zonation.
+- [`examples/barotropicqgql_betaforced.jl`](../generated/barotropicqgql_betaforced/): A script that simulates forced-dissipative quasi-linear quasi-geostrophic flow on a beta-plane demonstrating zonation. The forcing is temporally delta-correlated and its spatial structure is isotropic with power in a narrow annulus of total radius ``k_f`` in wavenumber space. This example demonstrates that the anisotropic inverse energy cascade is not required for zonation.

--- a/docs/src/modules/multilayerqg.md
+++ b/docs/src/modules/multilayerqg.md
@@ -146,5 +146,4 @@ GeophysicalFlows.MultiLayerQG.fluxes
 
 ## Examples
 
- - [`examples/multilayerqg_2layer.jl`](../generated/multilayerqg_2layer/): A script that 
-   simulates the growth and equilibration of baroclinic eddy turbulence in the Phillips 2-layer model.
+ - [`examples/multilayerqg_2layer.jl`](../generated/multilayerqg_2layer/): A script that simulates the growth and equilibration of baroclinic eddy turbulence in the Phillips 2-layer model.

--- a/docs/src/modules/multilayerqg.md
+++ b/docs/src/modules/multilayerqg.md
@@ -1,4 +1,4 @@
-# MultiLayerQG Module
+# MultiLayerQG
 
 ### Basic Equations
 
@@ -146,4 +146,5 @@ GeophysicalFlows.MultiLayerQG.fluxes
 
 ## Examples
 
- - `examples/multilayerqg_2layer.jl`: A script that simulates the growth and equilibration of baroclinic eddy turbulence in the Phillips 2-layer model.
+ - [`examples/multilayerqg_2layer.jl`](../generated/multilayerqg_2layer/): A script that 
+   simulates the growth and equilibration of baroclinic eddy turbulence in the Phillips 2-layer model.

--- a/docs/src/modules/singlelayerqg.md
+++ b/docs/src/modules/singlelayerqg.md
@@ -1,4 +1,4 @@
-# SingleLayerQG Module
+# SingleLayerQG
 
 ### Basic Equations
 
@@ -110,10 +110,18 @@ Other diagnostic include: [`energy_dissipation`](@ref GeophysicalFlows.SingleLay
 
 ## Examples
 
-- `examples/singlelayerqg_betadecay.jl`: A script that simulates decaying quasi-geostrophic flow on a beta-plane demonstrating zonation.
+- [`examples/singlelayerqg_betadecay.jl`](../generated/singlelayerqg_betadecay/): A script that 
+  simulates decaying quasi-geostrophic flow on a beta-plane demonstrating zonation.
 
-- `examples/singlelayerqg_betaforced.jl`: A script that simulates forced-dissipative quasi-geostrophic flow on a beta plane demonstrating zonation. The forcing is temporally delta-correlated with isotropic spatial structure with power in a narrow annulus in wavenumber space that corresponds to total wavenumber ``k_f``.
+- [`examples/singlelayerqg_betaforced.jl`](../generated/singlelayerqg_betaforced/): A script that 
+  simulates forced-dissipative quasi-geostrophic flow on a beta plane demonstrating zonation. 
+	The forcing is temporally delta-correlated with isotropic spatial structure with power in 
+	a narrow annulus in wavenumber space with total wavenumber ``k_f``.
 
-- `examples/singlelayerqg_decay_topography.jl`: A script that simulates two dimensional turbulence (barotropic quasi-geostrophic flow with ``\beta=0``) above topography.
+- [`examples/singlelayerqg_decay_topography.jl`](../generated/singlelayerqg_decay_topography/): 
+  A script that simulates two dimensional turbulence (barotropic quasi-geostrophic flow with 
+	``\beta=0``) above topography.
 
-- `examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl`: A script that simulates two dimensional turbulence (``\beta=0``) with both infinite and finite Rossby radius of deformation and compares the evolution of the two.
+- [`examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl`](../generated singlelayerqg_decaying_barotropic_equivalentbarotropic/): 
+  A script that simulates two dimensional turbulence (``\beta=0``) with both infinite and finite 
+	Rossby radius of deformation and compares the evolution of the two.

--- a/docs/src/modules/singlelayerqg.md
+++ b/docs/src/modules/singlelayerqg.md
@@ -110,18 +110,10 @@ Other diagnostic include: [`energy_dissipation`](@ref GeophysicalFlows.SingleLay
 
 ## Examples
 
-- [`examples/singlelayerqg_betadecay.jl`](../generated/singlelayerqg_betadecay/): A script that 
-  simulates decaying quasi-geostrophic flow on a beta-plane demonstrating zonation.
+- [`examples/singlelayerqg_betadecay.jl`](../generated/singlelayerqg_betadecay/): A script that simulates decaying quasi-geostrophic flow on a beta-plane demonstrating zonation.
 
-- [`examples/singlelayerqg_betaforced.jl`](../generated/singlelayerqg_betaforced/): A script that 
-  simulates forced-dissipative quasi-geostrophic flow on a beta plane demonstrating zonation. 
-	The forcing is temporally delta-correlated with isotropic spatial structure with power in 
-	a narrow annulus in wavenumber space with total wavenumber ``k_f``.
+- [`examples/singlelayerqg_betaforced.jl`](../generated/singlelayerqg_betaforced/): A script that simulates forced-dissipative quasi-geostrophic flow on a beta plane demonstrating zonation. The forcing is temporally delta-correlated with isotropic spatial structure with power in a narrow annulus in wavenumber space with total wavenumber ``k_f``.
 
-- [`examples/singlelayerqg_decay_topography.jl`](../generated/singlelayerqg_decay_topography/): 
-  A script that simulates two dimensional turbulence (barotropic quasi-geostrophic flow with 
-	``\beta=0``) above topography.
+- [`examples/singlelayerqg_decay_topography.jl`](../generated/singlelayerqg_decay_topography/): A script that simulates two dimensional turbulence (barotropic quasi-geostrophic flow with ``\beta=0``) above topography.
 
-- [`examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl`](../generated singlelayerqg_decaying_barotropic_equivalentbarotropic/): 
-  A script that simulates two dimensional turbulence (``\beta=0``) with both infinite and finite 
-	Rossby radius of deformation and compares the evolution of the two.
+- [`examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl`](../generated singlelayerqg_decaying_barotropic_equivalentbarotropic/): A script that simulates two dimensional turbulence (``\beta=0``) with both infinite and finite Rossby radius of deformation and compares the evolution of the two.

--- a/docs/src/modules/surfaceqg.md
+++ b/docs/src/modules/surfaceqg.md
@@ -1,4 +1,4 @@
-# SurfaceQG Module
+# SurfaceQG
 
 ### Basic Equations
 
@@ -96,6 +96,9 @@ Other diagnostic include: [`buoyancy_dissipation`](@ref GeophysicalFlows.Surface
 
 ## Examples
 
-- `examples/surfaceqg_decaying.jl`: A script that simulates decaying surface quasi-geostrophic flow with a prescribed initial buoyancy field, producing a video of the evolution of buoyancy and velocity fields.
+- [`examples/surfaceqg_decaying.jl`](../generated/surfaceqg_decaying/): A script that simulates 
+  decaying surface quasi-geostrophic flow with a prescribed initial buoyancy field, producing 
+  an animation of the evolution of the surface buoyancy.
 
-  > Capet, X. et al., (2008). Surface kinetic energy transfer in surface quasi-geostrophic flows. *J. Fluid Mech.*, **604**, 165-174.
+  > Capet, X. et al., (2008). Surface kinetic energy transfer in surface quasi-geostrophic 
+  flows. *J. Fluid Mech.*, **604**, 165-174.

--- a/docs/src/modules/surfaceqg.md
+++ b/docs/src/modules/surfaceqg.md
@@ -96,9 +96,6 @@ Other diagnostic include: [`buoyancy_dissipation`](@ref GeophysicalFlows.Surface
 
 ## Examples
 
-- [`examples/surfaceqg_decaying.jl`](../generated/surfaceqg_decaying/): A script that simulates 
-  decaying surface quasi-geostrophic flow with a prescribed initial buoyancy field, producing 
-  an animation of the evolution of the surface buoyancy.
+- [`examples/surfaceqg_decaying.jl`](../generated/surfaceqg_decaying/): A script that simulates decaying surface quasi-geostrophic flow with a prescribed initial buoyancy field, producing an animation of the evolution of the surface buoyancy.
 
-  > Capet, X. et al., (2008). Surface kinetic energy transfer in surface quasi-geostrophic 
-  flows. *J. Fluid Mech.*, **604**, 165-174.
+  > Capet, X. et al., (2008). Surface kinetic energy transfer in surface quasi-geostrophic flows. *J. Fluid Mech.*, **604**, 165-174.

--- a/docs/src/modules/twodnavierstokes.md
+++ b/docs/src/modules/twodnavierstokes.md
@@ -1,11 +1,11 @@
-# TwoDNavierStokes Module
+# TwoDNavierStokes
 
 
 ### Basic Equations
 
 This module solves two-dimensional incompressible Navier-Stokes equations using the 
-vorticity-streamfunction formulation. The flow ``\boldsymbol{u} = (u, v)`` is obtained through 
-a streamfunction ``\psi`` as ``(u, v) = (-\partial_y \psi, \partial_x \psi)``. The only non-zero 
+vorticity-streamfunction formulation. The flow ``\bm{u} = (u, v)`` is obtained through a 
+streamfunction ``\psi`` as ``(u, v) = (-\partial_y \psi, \partial_x \psi)``. The only non-zero 
 component of vorticity is that normal to the plane of motion, 
 ``\partial_x v - \partial_y u = \nabla^2 \psi``. The module solves the two-dimensional 
 vorticity equation:
@@ -90,10 +90,16 @@ Other diagnostic include: [`energy_dissipation`](@ref GeophysicalFlows.TwoDNavie
 
 ## Examples
 
-- `examples/twodnavierstokes_decaying.jl`: A script that simulates decaying two-dimensional turbulence reproducing the results by
+- [`examples/twodnavierstokes_decaying.jl`](../generated/twodnavierstokes_decaying/): A script 
+  that simulates decaying two-dimensional turbulence reproducing the results by
 
-  > McWilliams, J. C. (1984). The emergence of isolated coherent vortices in turbulent flow. *J. Fluid Mech.*, **146**, 21-43.
+  > McWilliams, J. C. (1984). The emergence of isolated coherent vortices in turbulent flow. 
+  *J. Fluid Mech.*, **146**, 21-43.
 
-- `examples/twodnavierstokes_stochasticforcing.jl`: A script that simulates forced-dissipative two-dimensional turbulence with isotropic temporally delta-correlated stochastic forcing.
+- [`examples/twodnavierstokes_stochasticforcing.jl`](../generated/twodnavierstokes_stochasticforcing/): 
+  A script that simulates forced-dissipative two-dimensional turbulence with isotropic temporally 
+  delta-correlated stochastic forcing.
 
-- `examples/twodnavierstokes_stochasticforcing_budgets.jl`: A script that simulates forced-dissipative two-dimensional turbulence demonstrating how we can compute the energy and enstrophy budgets.
+- [`examples/twodnavierstokes_stochasticforcing_budgets.jl`](../generated/twodnavierstokes_stochasticforcing_budgets/): 
+  A script that simulates forced-dissipative two-dimensional turbulence demonstrating how we 
+  can compute the energy and enstrophy budgets.

--- a/docs/src/modules/twodnavierstokes.md
+++ b/docs/src/modules/twodnavierstokes.md
@@ -90,16 +90,10 @@ Other diagnostic include: [`energy_dissipation`](@ref GeophysicalFlows.TwoDNavie
 
 ## Examples
 
-- [`examples/twodnavierstokes_decaying.jl`](../generated/twodnavierstokes_decaying/): A script 
-  that simulates decaying two-dimensional turbulence reproducing the results by
+- [`examples/twodnavierstokes_decaying.jl`](../generated/twodnavierstokes_decaying/): A script that simulates decaying two-dimensional turbulence reproducing the results by
 
-  > McWilliams, J. C. (1984). The emergence of isolated coherent vortices in turbulent flow. 
-  *J. Fluid Mech.*, **146**, 21-43.
+  > McWilliams, J. C. (1984). The emergence of isolated coherent vortices in turbulent flow. *J. Fluid Mech.*, **146**, 21-43.
 
-- [`examples/twodnavierstokes_stochasticforcing.jl`](../generated/twodnavierstokes_stochasticforcing/): 
-  A script that simulates forced-dissipative two-dimensional turbulence with isotropic temporally 
-  delta-correlated stochastic forcing.
+- [`examples/twodnavierstokes_stochasticforcing.jl`](../generated/twodnavierstokes_stochasticforcing/): A script that simulates forced-dissipative two-dimensional turbulence with isotropic temporally delta-correlated stochastic forcing.
 
-- [`examples/twodnavierstokes_stochasticforcing_budgets.jl`](../generated/twodnavierstokes_stochasticforcing_budgets/): 
-  A script that simulates forced-dissipative two-dimensional turbulence demonstrating how we 
-  can compute the energy and enstrophy budgets.
+- [`examples/twodnavierstokes_stochasticforcing_budgets.jl`](../generated/twodnavierstokes_stochasticforcing_budgets/): A script that simulates forced-dissipative two-dimensional turbulence demonstrating how we can compute the energy and enstrophy budgets.


### PR DESCRIPTION
This PR:

- Removes repeated "Module" from all module titles in Docs.
- Adds links to all examples in module pages in Docs.