### PR TITLE
Simplify examples

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,11 +3,10 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FourierFlows = "2aec4490-903f-5c70-9b11-9bed06a700e1"
-GeophysicalFlows = "44ee3b1c-bc02-53fa-8355-8e347616e15e"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-FourierFlows = "≥ 0.6.16"
+FourierFlows = "≥ 0.6.17"
 Plots = "≥ 1.10.1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-push!(LOAD_PATH, "..")
+push!(LOAD_PATH, joinpath(@__DIR__, "..")) # add GeophysicalFlows to environment stack
 
 using
   Documenter,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,3 @@
-push!(LOAD_PATH, joinpath(@__DIR__, "..")) # add GeophysicalFlows to environment stack
-
 using
   Documenter,
   Literate,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using
   Documenter,
   Literate,
-  Plots,  # to not capture precompilation output
+  Plots,   # to not capture precompilation output
   GeophysicalFlows
 
 # Gotta set this environment variable when using the GR run-time on Travis CI.

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -10,5 +10,5 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-FourierFlows = "≥ 0.6.16"
+FourierFlows = "≥ 0.6.17"
 Plots = "≥ 1.10.1"

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -5,15 +5,23 @@
 # A simulation of forced-dissipative barotropic quasi-geostrophic turbulence on 
 # a beta plane under the *quasi-linear approximation*. The dynamics include 
 # linear drag and stochastic excitation.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
 
-using CUDA, FourierFlows, Random, Statistics, Printf, Plots
+# ```julia
+# using Pkg
+# pkg"add GeophysicalFlows, Random, Statistics, Printf, Plots"
+# ```
+
+# ## Let's begin
+# Let's load `GeophysicalFlows.jl` and some other needed packages.
+#
+using GeophysicalFlows, Random, Printf, Plots
 
 using FourierFlows: parsevalsum
-using FFTW: irfft
 using Statistics: mean
-
-import GeophysicalFlows.BarotropicQGQL
-import GeophysicalFlows.BarotropicQGQL: energy, enstrophy
 
 
 # ## Choosing a device: CPU or GPU
@@ -126,8 +134,8 @@ nothing # hide
 # ## Diagnostics
 
 # Create Diagnostics -- `energy` and `enstrophy` are functions imported at the top.
-E = Diagnostic(energy, prob; nsteps=nsteps)
-Z = Diagnostic(enstrophy, prob; nsteps=nsteps)
+E = Diagnostic(BarotropicQGQL.energy, prob; nsteps=nsteps)
+Z = Diagnostic(BarotropicQGQL.enstrophy, prob; nsteps=nsteps)
 nothing # hide
 
 # We can also define our custom diagnostics via functions.

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -5,13 +5,22 @@
 # A simulation of the growth of barolinic instability in the Phillips 2-layer model
 # when we impose a vertical mean flow shear as a difference ``\Delta U`` in the
 # imposed, domain-averaged, zonal flow at each layer.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
 
-using FourierFlows, Plots, Printf
+# ```julia
+# using Pkg
+# pkg"add GeophysicalFlows, Plots, Printf"
+# ```
 
-using FFTW: rfft, irfft
+# ## Let's begin
+# Let's load `GeophysicalFlows.jl` and some other needed packages.
+#
+using GeophysicalFlows, Plots, Printf
+
 using Random: seed!
-import GeophysicalFlows.MultiLayerQG
-import GeophysicalFlows.MultiLayerQG: energies
 
 
 # ## Choosing a device: CPU or GPU
@@ -76,7 +85,7 @@ nothing # hide
 # ## Diagnostics
 
 # Create Diagnostics -- `energies` function is imported at the top.
-E = Diagnostic(energies, prob; nsteps=nsteps)
+E = Diagnostic(MultiLayerQG.energies, prob; nsteps=nsteps)
 diags = [E] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
 nothing # hide
 

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -3,14 +3,23 @@
 #md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/singlelayerqg_betadecay.ipynb).
 # 
 # An example of decaying barotropic quasi-geostrophic turbulence on a beta plane.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
 
-using FourierFlows, Plots, Printf, Random
+# ```julia
+# using Pkg
+# pkg"add GeophysicalFlows, Plots, Printf, Statistics, Random"
+# ```
+
+# ## Let's begin
+# Let's load `GeophysicalFlows.jl` and some other needed packages.
+#
+using GeophysicalFlows, Plots, Printf, Random
 
 using Statistics: mean
-using FFTW: irfft
 
-import GeophysicalFlows.SingleLayerQG
-import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 # ## Choosing a device: CPU or GPU
 
@@ -65,7 +74,7 @@ q₀h = ArrayType(dev)(randn(Complex{eltype(grid)}, size(sol)))
 @. q₀h = ifelse(K < 6  * 2π/L, 0, q₀h)
 @. q₀h = ifelse(K > 10 * 2π/L, 0, q₀h)
 @. q₀h[1, :] = 0    # remove any power from zonal wavenumber k=0
-q₀h *= sqrt(E₀ / energy(q₀h, vars, params, grid)) # normalize q₀ to have energy E₀
+q₀h *= sqrt(E₀ / SingleLayerQG.energy(q₀h, vars, params, grid)) # normalize q₀ to have energy E₀
 q₀ = irfft(q₀h, grid.nx)
 
 SingleLayerQG.set_q!(prob, q₀)
@@ -109,8 +118,8 @@ p = plot(p1, p2, layout = layout, size = (800, 360))
 # ## Diagnostics
 
 # Create Diagnostics -- `energy` and `enstrophy` functions are imported at the top.
-E = Diagnostic(energy, prob; nsteps=nsteps)
-Z = Diagnostic(enstrophy, prob; nsteps=nsteps)
+E = Diagnostic(SingleLayerQG.energy, prob; nsteps=nsteps)
+Z = Diagnostic(SingleLayerQG.enstrophy, prob; nsteps=nsteps)
 diags = [E, Z] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
 nothing # hide
 

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -4,15 +4,23 @@
 #
 # A simulation of forced-dissipative barotropic quasi-geostrophic turbulence on 
 # a beta plane. The dynamics include linear drag and stochastic excitation.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
 
-using CUDA, FourierFlows, Random, Printf, Plots, Statistics
+# ```julia
+# using Pkg
+# pkg"add GeophysicalFlows, Random, Printf, Plots, Statistics"
+# ```
+
+# ## Let's begin
+# Let's load `GeophysicalFlows.jl` and some other needed packages.
+#
+using GeophysicalFlows, Random, Printf, Plots
 
 using FourierFlows: parsevalsum
-using FFTW: irfft
 using Statistics: mean
-
-import GeophysicalFlows.SingleLayerQG
-import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 
 # ## Choosing a device: CPU or GPU
@@ -125,8 +133,8 @@ SingleLayerQG.set_q!(prob, ArrayType(dev)(zeros(grid.nx, grid.ny)))
 # ## Diagnostics
 
 # Create Diagnostic -- `energy` and `enstrophy` are functions imported at the top.
-E = Diagnostic(energy, prob; nsteps=nsteps)
-Z = Diagnostic(enstrophy, prob; nsteps=nsteps)
+E = Diagnostic(SingleLayerQG.energy, prob; nsteps=nsteps)
+Z = Diagnostic(SingleLayerQG.enstrophy, prob; nsteps=nsteps)
 diags = [E, Z] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
 nothing # hide
 

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -4,14 +4,23 @@
 #
 # We use here the `SingleLayerQG` module to simulate decaying two-dimensional turbulence and
 # investigate how does a finite Rossby radius of deformation affects its evolution.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
 
-using FourierFlows, Printf, Random, Plots
+# ```julia
+# using Pkg
+# pkg"add GeophysicalFlows, Printf, Random, Plots"
+# ```
+
+# ## Let's begin
+# Let's load `GeophysicalFlows.jl` and some other needed packages.
+#
+using GeophysicalFlows, Printf, Random, Plots
  
+using GeophysicalFlows: peakedisotropicspectrum
 using Random: seed!
-using FFTW: rfft, irfft
-
-import GeophysicalFlows.SingleLayerQG
-import GeophysicalFlows: peakedisotropicspectrum
 
 
 # ## Choosing a device: CPU or GPU

--- a/examples/singlelayerqg_decaying_topography.jl
+++ b/examples/singlelayerqg_decaying_topography.jl
@@ -3,14 +3,22 @@
 #md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/singlelayerqg_decaying_topography.ipynb).
 # 
 # An example of decaying barotropic quasi-geostrophic turbulence over topography.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
 
-using FourierFlows, Plots, Printf, Random
+# ```julia
+# using Pkg
+# pkg"add GeophysicalFlows, Plots, Printf, Random, Statistics"
+# ```
+
+# ## Let's begin
+# Let's load `GeophysicalFlows.jl` and some other needed packages.
+#
+using GeophysicalFlows, Plots, Printf, Random
 
 using Statistics: mean
-using FFTW: irfft
-
-import GeophysicalFlows.SingleLayerQG
-import GeophysicalFlows.SingleLayerQG: energy, enstrophy
 
 
 # ## Choosing a device: CPU or GPU
@@ -87,7 +95,7 @@ Random.seed!(1234)
 qih = ArrayType(dev)(randn(Complex{eltype(grid)}, size(sol)))
 @. qih = ifelse(K < 6  * 2π/L, 0, qih)
 @. qih = ifelse(K > 12 * 2π/L, 0, qih)
-qih *= sqrt(E₀ / energy(qih, vars, params, grid))  # normalize qi to have energy E₀
+qih *= sqrt(E₀ / SingleLayerQG.energy(qih, vars, params, grid))  # normalize qi to have energy E₀
 qi = irfft(qih, grid.nx)
 
 SingleLayerQG.set_q!(prob, qi)
@@ -129,8 +137,8 @@ p = plot(p1, p2, layout=layout, size = (800, 360))
 # ## Diagnostics
 
 # Create Diagnostics -- `energy` and `enstrophy` functions are imported at the top.
-E = Diagnostic(energy, prob; nsteps=nsteps)
-Z = Diagnostic(enstrophy, prob; nsteps=nsteps)
+E = Diagnostic(SingleLayerQG.energy, prob; nsteps=nsteps)
+Z = Diagnostic(SingleLayerQG.enstrophy, prob; nsteps=nsteps)
 diags = [E, Z] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
 nothing # hide
 

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -6,15 +6,25 @@
 # A simulation of decaying surface quasi-geostrophic turbulence.
 # We reproduce here the initial value problem for an elliptical 
 # vortex as done by Held et al. 1995, _J. Fluid Mech_.
+# 
+# An example of decaying barotropic quasi-geostrophic turbulence over topography.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
 
-using FourierFlows, Plots, Statistics, Printf, Random
+# ```julia
+# using Pkg
+# pkg"add GeophysicalFlows, Plots, Printf, Random, Statistics"
+# ```
 
-using FFTW: irfft
+# ## Let's begin
+# Let's load `GeophysicalFlows.jl` and some other needed packages.
+#
+using GeophysicalFlows, Plots, Printf, Random
+
 using Statistics: mean
 using Random: seed!
-
-import GeophysicalFlows.SurfaceQG
-import GeophysicalFlows.SurfaceQG: kinetic_energy, buoyancy_variance, buoyancy_dissipation
 
 
 # ## Choosing a device: CPU or GPU
@@ -84,9 +94,9 @@ heatmap(x, y, Array(vars.b'),
 
 # Create Diagnostics; `buoyancy_variance`, `kinetic_energy` and `buoyancy_dissipation` 
 # functions were imported at the top.
-B  = Diagnostic(buoyancy_variance, prob; nsteps=nsteps)
-KE = Diagnostic(kinetic_energy, prob; nsteps=nsteps)
-Dᵇ = Diagnostic(buoyancy_dissipation, prob; nsteps=nsteps)
+B  = Diagnostic(SurfaceQG.buoyancy_variance, prob; nsteps=nsteps)
+KE = Diagnostic(SurfaceQG.kinetic_energy, prob; nsteps=nsteps)
+Dᵇ = Diagnostic(SurfaceQG.buoyancy_dissipation, prob; nsteps=nsteps)
 diags = [B, KE, Dᵇ] # A list of Diagnostics types passed to `stepforward!`. Diagnostics are updated every timestep.
 nothing # hidenothing # hide
 

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -3,15 +3,25 @@
 #md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/twodnavierstokes_decaying.ipynb).
 #
 # A simulation of decaying two-dimensional turbulence.
+# 
+# An example of decaying barotropic quasi-geostrophic turbulence over topography.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
 
-using FourierFlows, Printf, Random, Plots
+# ```julia
+# using Pkg
+# pkg"add GeophysicalFlows, Printf, Random, Plots"
+# ```
+
+# ## Let's begin
+# Let's load `GeophysicalFlows.jl` and some other needed packages.
+#
+using GeophysicalFlows, Printf, Random, Plots
  
 using Random: seed!
-using FFTW: rfft, irfft
-
-import GeophysicalFlows.TwoDNavierStokes
-import GeophysicalFlows.TwoDNavierStokes: energy, enstrophy
-import GeophysicalFlows: peakedisotropicspectrum
+using GeophysicalFlows: peakedisotropicspectrum
 
 
 # ## Choosing a device: CPU or GPU
@@ -75,8 +85,8 @@ heatmap(x, y, Array(vars.ζ'),
 # ## Diagnostics
 
 # Create Diagnostics -- `energy` and `enstrophy` functions are imported at the top.
-E = Diagnostic(energy, prob; nsteps=nsteps)
-Z = Diagnostic(enstrophy, prob; nsteps=nsteps)
+E = Diagnostic(TwoDNavierStokes.energy, prob; nsteps=nsteps)
+Z = Diagnostic(TwoDNavierStokes.enstrophy, prob; nsteps=nsteps)
 diags = [E, Z] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
 nothing # hide
 

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -5,14 +5,21 @@
 # A simulation of forced-dissipative two-dimensional turbulence. We solve the
 # two-dimensional vorticity equation with stochastic excitation and dissipation in
 # the form of linear drag and hyperviscosity. 
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
 
-using CUDA, FourierFlows, Random, Printf, Plots
+# ```julia
+# using Pkg
+# pkg"add GeophysicalFlows, Random, Printf, Plots"
+# ```
 
+# ## Let's begin
+# Let's load `GeophysicalFlows.jl` and some other needed packages.
+#
+using GeophysicalFlows, Random, Printf, Plots
 using FourierFlows: parsevalsum
-using FFTW: irfft
-
-import GeophysicalFlows.TwoDNavierStokes
-import GeophysicalFlows.TwoDNavierStokes: energy, enstrophy
 
 
 # ## Choosing a device: CPU or GPU
@@ -122,8 +129,8 @@ TwoDNavierStokes.set_ζ!(prob, ArrayType(dev)(zeros(grid.nx, grid.ny)))
 # ## Diagnostics
 
 # Create Diagnostics; the diagnostics are aimed to probe the energy budget.
-E  = Diagnostic(energy,                prob, nsteps=nsteps) # energy
-Z  = Diagnostic(enstrophy,             prob, nsteps=nsteps) # enstrophy
+E  = Diagnostic(TwoDNavierStokes.energy,                prob, nsteps=nsteps) # energy
+Z  = Diagnostic(TwoDNavierStokes.enstrophy,             prob, nsteps=nsteps) # enstrophy
 diags = [E, Z] # a list of Diagnostics passed to `stepforward!` will  be updated every timestep.
 nothing # hide
 

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -7,15 +7,21 @@
 # the form of linear drag and hyperviscosity. As a demonstration, we compute how
 # each of the forcing and dissipation terms contribute to the energy and the 
 # enstrophy budgets.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
 
-using CUDA, FourierFlows, Random, Printf, Plots
+# ```julia
+# using Pkg
+# pkg"add GeophysicalFlows, Random, Printf, Plots"
+# ```
 
+# ## Let's begin
+# Let's load `GeophysicalFlows.jl` and some other needed packages.
+#
+using GeophysicalFlows, Random, Printf, Plots
 using FourierFlows: parsevalsum
-using FFTW: irfft
-
-import GeophysicalFlows.TwoDNavierStokes
-import GeophysicalFlows.TwoDNavierStokes: energy, energy_dissipation_hyperviscosity, energy_dissipation_hypoviscosity, energy_work
-import GeophysicalFlows.TwoDNavierStokes: enstrophy, enstrophy_dissipation_hyperviscosity, enstrophy_dissipation_hypoviscosity, enstrophy_work
 
 
 # ## Choosing a device: CPU or GPU
@@ -125,14 +131,14 @@ TwoDNavierStokes.set_ζ!(prob, ArrayType(dev)(zeros(grid.nx, grid.ny)))
 # ## Diagnostics
 
 # Create Diagnostics; the diagnostics are aimed to probe the energy and enstrophy budgets.
-E  = Diagnostic(energy,                               prob, nsteps=nt) # energy
-Rᵋ = Diagnostic(energy_dissipation_hypoviscosity,     prob, nsteps=nt) # energy dissipation by drag μ
-Dᵋ = Diagnostic(energy_dissipation_hyperviscosity,    prob, nsteps=nt) # energy dissipation by drag μ
-Wᵋ = Diagnostic(energy_work,                          prob, nsteps=nt) # energy work input by forcing
-Z  = Diagnostic(enstrophy,                            prob, nsteps=nt) # enstrophy
-Rᶻ = Diagnostic(enstrophy_dissipation_hypoviscosity,  prob, nsteps=nt) # enstrophy dissipation by drag μ
-Dᶻ = Diagnostic(enstrophy_dissipation_hyperviscosity, prob, nsteps=nt) # enstrophy dissipation by drag μ
-Wᶻ = Diagnostic(enstrophy_work,                       prob, nsteps=nt) # enstrophy work input by forcing
+E  = Diagnostic(TwoDNavierStokes.energy,                               prob, nsteps=nt) # energy
+Rᵋ = Diagnostic(TwoDNavierStokes.energy_dissipation_hypoviscosity,     prob, nsteps=nt) # energy dissipation by drag μ
+Dᵋ = Diagnostic(TwoDNavierStokes.energy_dissipation_hyperviscosity,    prob, nsteps=nt) # energy dissipation by drag μ
+Wᵋ = Diagnostic(TwoDNavierStokes.energy_work,                          prob, nsteps=nt) # energy work input by forcing
+Z  = Diagnostic(TwoDNavierStokes.enstrophy,                            prob, nsteps=nt) # enstrophy
+Rᶻ = Diagnostic(TwoDNavierStokes.enstrophy_dissipation_hypoviscosity,  prob, nsteps=nt) # enstrophy dissipation by drag μ
+Dᶻ = Diagnostic(TwoDNavierStokes.enstrophy_dissipation_hyperviscosity, prob, nsteps=nt) # enstrophy dissipation by drag μ
+Wᶻ = Diagnostic(TwoDNavierStokes.enstrophy_work,                       prob, nsteps=nt) # enstrophy work input by forcing
 diags = [E, Dᵋ, Wᵋ, Rᵋ, Z, Dᶻ, Wᶻ, Rᶻ] # a list of Diagnostics passed to `stepforward!` will  be updated every timestep.
 nothing # hide
 

--- a/src/GeophysicalFlows.jl
+++ b/src/GeophysicalFlows.jl
@@ -7,12 +7,12 @@ module GeophysicalFlows
 
 using
   CUDA,
-  FourierFlows,
   Statistics,
   SpecialFunctions,
+  Reexport,
   DocStringExtensions
 
-using FFTW: irfft
+@reexport using FourierFlows
 
 include("utils.jl")
 include("twodnavierstokes.jl")
@@ -20,5 +20,11 @@ include("singlelayerqg.jl")
 include("multilayerqg.jl")
 include("surfaceqg.jl")
 include("barotropicqgql.jl")
+
+@reexport using GeophysicalFlows.TwoDNavierStokes
+@reexport using GeophysicalFlows.SingleLayerQG
+@reexport using GeophysicalFlows.MultiLayerQG
+@reexport using GeophysicalFlows.SurfaceQG
+@reexport using GeophysicalFlows.BarotropicQGQL
 
 end # module


### PR DESCRIPTION
This PR simplifies the examples. Now common functions from FFTW and CUDA packages are re-exported by FourierFlows. Also, FourierFlows namespace is reexported by GeophysicalFlows. Thus, `using GeophysicalFlows` suffices for running simulations. The users still need to load, e.g.,`Plots.jl` if they want to plot the output.

(Inspired by @pdebuyl's remark in [JOSS paper review](https://github.com/openjournals/joss-reviews/issues/3053#issuecomment-818964253).)

Closes #33.
