### PR TITLE
Drop the in-house `@has_cuda` macro

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using
-  CUDA,
-  FourierFlows,
+  GeophysicalFlows
   Statistics,
   Random,
   FFTW,
@@ -17,8 +16,7 @@ using FourierFlows: parsevalsum
 using GeophysicalFlows: lambdipole, peakedisotropicspectrum
 
 # the devices on which tests will run
-devices = (CPU(),)
-@has_cuda devices = (CPU(), GPU())
+devices = CUDA.has_cuda() ? (CPU(), GPU()) : (CPU(),)
 
 const rtol_lambdipole = 1e-2 # tolerance for lamb dipole tests
 const rtol_twodnavierstokes = 1e-13 # tolerance for twodnavierstokes forcing tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using
-  GeophysicalFlows
+  GeophysicalFlows,
   Statistics,
   Random,
   FFTW,


### PR DESCRIPTION
Drops use of deprecated `FourierFlows.@has_cuda` in favor of `CUDA.has_cuda()`.