### PR TITLE
Use FourierFlows v0.6.19 that resolves FourierFlows/FourierFlows.jl#281

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "GeophysicalFlows"
 uuid = "44ee3b1c-bc02-53fa-8355-8e347616e15e"
 license = "MIT"
 authors = ["Navid C. Constantinou <navidcy@gmail.com>", "Gregory L. Wagner <wagner.greg@gmail.com>", "and co-contributors"]
-version = "0.12.2"
+version = "0.12.3"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -21,7 +21,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 CUDA = "^1, ^2.4.2, ^3.0"
 DocStringExtensions = "^0.8"
 FFTW = "^1"
-FourierFlows = "^0.6.17"
+FourierFlows = "^0.6.19"
 JLD2 = "^0.1, ^0.2, ^0.3, ^0.4"
 Reexport = "^0.2, ^1"
 SpecialFunctions = "^0.10, ^1"

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ The user is also referred to the [GPU section](https://fourierflows.github.io/Fo
 
 ## Getting help
 
-If you are interested in using GeophysicalFlows.jl or are trying to figure out how to use it, 
-please feel free to ask us questions and get in touch! Check out the 
+Interested in GeophysicalFlows.jl or trying to figure out how to use it? Please feel free to 
+ask us questions and get in touch! Check out the 
 [examples](https://github.com/FourierFlows/GeophysicalFlows.jl/tree/master/examples) and 
 [open an issue](https://github.com/FourierFlows/GeophysicalFlows.jl/issues/new) or 
 [start a discussion](https://github.com/FourierFlows/GeophysicalFlows.jl/discussions/new) 


### PR DESCRIPTION
This PR ups compat requirement for FourierFlows.jl to v0.6.19, which includes a bug fix for https://github.com/FourierFlows/FourierFlows.jl/issues/281.