### PR TITLE
Avoid using scalar operations in `calcF!` in the examples

### DIFF
--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -17,7 +17,7 @@
 
 # ## Let's begin
 # Let's load `GeophysicalFlows.jl` and some other needed packages.
-#
+
 using GeophysicalFlows, Random, Printf, Plots
 
 using FourierFlows: parsevalsum
@@ -66,6 +66,8 @@ grid = TwoDGrid(dev, n, L)
 K = @. sqrt(grid.Krsq)            # a 2D array with the total wavenumber
 
 forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2))
+@CUDA.allowscalar forcing_spectrum[grid.Krsq .== 0] .= 0 # ensure forcing has zero domain-average
+
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
 @. forcing_spectrum *= ε/ε0       # normalize forcing to inject energy at rate ε
 nothing # hide
@@ -83,8 +85,6 @@ random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid) 
   Fh .= sqrt.(forcing_spectrum) .* exp.(2π * im * random_uniform(eltype(grid), size(sol))) ./ sqrt(clock.dt)
-
-  @CUDA.allowscalar Fh[1, 1] = 0 # make sure forcing has zero domain-average
 
   return nothing
 end

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -59,6 +59,8 @@ grid = TwoDGrid(dev, n, L)
 K = @. sqrt(grid.Krsq)             # a 2D array with the total wavenumber
 
 forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2))
+@CUDA.allowscalar forcing_spectrum[grid.Krsq .== 0] .= 0 # ensure forcing has zero domain-average
+
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
 @. forcing_spectrum *= ε/ε0        # normalize forcing to inject energy at rate ε
 nothing # hide
@@ -76,9 +78,7 @@ random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid) 
   Fh .= sqrt.(forcing_spectrum) .* exp.(2π * im * random_uniform(eltype(grid), size(sol))) ./ sqrt(clock.dt)
-
-  @CUDA.allowscalar Fh[1, 1] = 0 # make sure forcing has zero domain-average
-
+  
   return nothing
 end
 nothing # hide

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -61,6 +61,8 @@ grid = TwoDGrid(dev, n, L)
 K = @. sqrt(grid.Krsq)             # a 2D array with the total wavenumber
 
 forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2))
+@CUDA.allowscalar forcing_spectrum[grid.Krsq .== 0] .= 0 # ensure forcing has zero domain-average
+
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
 @. forcing_spectrum *= ε/ε0        # normalize forcing to inject energy at rate ε
 nothing # hide
@@ -78,8 +80,6 @@ random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid) 
   Fh .= sqrt.(forcing_spectrum) .* exp.(2π * im * random_uniform(eltype(grid), size(sol))) ./ sqrt(clock.dt)
-
-  @CUDA.allowscalar Fh[1, 1] = 0 # make sure forcing has zero domain-average
 
   return nothing
 end


### PR DESCRIPTION
This PR modifies the examples so that they avoid using scalar operations in `calcF!` functions.

(Scalar operations are slow on GPUs.)

Closes #241.