### PR TITLE
Removes unused imports of FFTW.jl

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FourierFlows = "2aec4490-903f-5c70-9b11-9bed06a700e1"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 GeophysicalFlows = "44ee3b1c-bc02-53fa-8355-8e347616e15e"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -22,7 +22,6 @@ using
 
 @reexport using FourierFlows
 
-using FFTW: rfft, irfft
 using FourierFlows: parsevalsum, parsevalsum2, superzeros, plan_flows_rfft
 
 nothingfunction(args...) = nothing

--- a/src/singlelayerqg.jl
+++ b/src/singlelayerqg.jl
@@ -23,7 +23,6 @@ using
 
 @reexport using FourierFlows
 
-using FFTW: rfft
 using LinearAlgebra: mul!, ldiv!
 using FourierFlows: parsevalsum, parsevalsum2
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using
   GeophysicalFlows,
   Statistics,
   Random,
-  FFTW,
   Test
 
 import # use 'import' rather than 'using' for submodules to keep namespace clean


### PR DESCRIPTION
Since FourierFlows.jl v0.6.17 functions `fft`, `rfft`, `ifft`, and `irfft` are exported from FourierFlows.jl.

Closes #248.