### PR TITLE
Removes dealiasing from some examples for better visualization

### DIFF
--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -92,12 +92,12 @@ nothing # hide
 
 
 # ## Problem setup
-# We initialize a `Problem` by providing a set of keyword arguments. Not providing
-# a viscosity coefficient ν leads to the module's default value: ν=0. In this
-# example numerical instability due to accumulation of enstrophy in high wavenumbers
-# is taken care with the `FilteredTimestepper` we picked. 
+# We initialize a `Problem` by providing a set of keyword arguments. Not providing a viscosity 
+# coefficient `ν` leads to the module's default value: `ν=0`. In this example numerical instability 
+# due to accumulation of enstrophy in high wavenumbers is taken care with the `FilteredTimestepper` 
+# we picked. Thus, we choose not to do any dealiasing by providing `aliased_fraction=0`.
 prob = BarotropicQGQL.Problem(dev; nx=n, Lx=L, β=β, μ=μ, dt=dt, stepper=stepper, 
-                              calcF=calcF!, stochastic=true)
+                              calcF=calcF!, stochastic=true, aliased_fraction=0)
 nothing # hide
 
 # and define some shortcuts.

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -45,11 +45,13 @@ L = 2π        # domain size
 nothing # hide
 
 # ## Problem setup
-# We initialize a `Problem` by providing a set of keyword arguments. Not providing
-# a viscosity coefficient `ν` leads to the module's default value: `ν=0`. In this
-# example numerical instability due to accumulation of enstrophy at high wavenumbers
-# is taken care with the `FilteredTimestepper` we picked. 
-prob = SingleLayerQG.Problem(dev; nx=n, Lx=L, β=β, μ=μ, dt=dt, stepper=stepper)
+# We initialize a `Problem` by providing a set of keyword arguments. Not providing a viscosity 
+# coefficient `ν` leads to the module's default value: `ν=0`. In this example numerical instability 
+# due to accumulation of enstrophy at high wavenumbers is taken care with the `FilteredTimestepper` 
+# we picked. Thus, we choose not to do any dealiasing by providing `aliased_fraction=0`.
+
+prob = SingleLayerQG.Problem(dev; nx=n, Lx=L, β=β, μ=μ,
+                                  dt=dt, stepper=stepper, aliased_fraction=0)
 nothing # hide
 
 # and define some shortcuts

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -223,6 +223,7 @@ function plot_output(prob)
 
   pE = plot(1,
              label = "energy",
+            legend = :bottomright,
          linewidth = 2,
              alpha = 0.7,
              xlims = (-0.1, 4.1),
@@ -236,7 +237,7 @@ function plot_output(prob)
          linewidth = 2,
              alpha = 0.7,
              xlims = (-0.1, 4.1),
-             ylims = (0, 2.5),
+             ylims = (0, 3),
             xlabel = "μt")
 
   l = @layout Plots.grid(2, 3)

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -48,8 +48,10 @@ nothing # hide
 # We initialize two problems by providing a set of keyword arguments to the `Problem` constructor.
 # The two problems are otherwise the same, except one has an infinite deformation radius, `prob_bqg`,
 # and the other has finite deformation radius, `prob_eqbqg`.
-prob_bqg = SingleLayerQG.Problem(dev; nx=n, Lx=L, dt=dt, stepper="FilteredRK4")
-prob_eqbqg = SingleLayerQG.Problem(dev; nx=n, Lx=L, deformation_radius = deformation_radius, dt=dt, stepper="FilteredRK4")
+prob_bqg = SingleLayerQG.Problem(dev; nx=n, Lx=L,
+                                      dt=dt, stepper="FilteredRK4", aliased_fraction=0)
+prob_eqbqg = SingleLayerQG.Problem(dev; nx=n, Lx=L, deformation_radius = deformation_radius,
+                                      dt=dt, stepper="FilteredRK4", aliased_fraction=0)
 nothing # hide
 
 

--- a/examples/singlelayerqg_decaying_topography.jl
+++ b/examples/singlelayerqg_decaying_topography.jl
@@ -49,12 +49,14 @@ topographicPV(x, y) = 3exp(-(x-1)^2/(2σx^2) -(y-1)^2/(2σy^2)) - 2exp(-(x+1)^2/
 nothing # hide
 
 # ## Problem setup
-# We initialize a `Problem` by providing a set of keyword arguments. Not providing
-# a viscosity coefficient `ν` leads to the module's default value: `ν=0`. In this
-# example numerical instability due to accumulation of enstrophy in high wavenumbers
-# is taken care with the `FilteredTimestepper` we picked. The topophic PV is prescribed
-# via keyword argument `eta`.
-prob = SingleLayerQG.Problem(dev; nx=n, Lx=L, eta=topographicPV, dt=dt, stepper=stepper)
+# We initialize a `Problem` by providing a set of keyword arguments. Not providing a viscosity 
+# coefficient `ν` leads to the module's default value: `ν=0`. In this example numerical instability 
+# due to accumulation of enstrophy in high wavenumbers is taken care with the `FilteredTimestepper` 
+# we picked. Thus, we choose not to do any dealiasing by providing `aliased_fraction=0`.
+#
+# The topophic PV is prescribed via keyword argument `eta`.
+prob = SingleLayerQG.Problem(dev; nx=n, Lx=L, eta=topographicPV,
+                                  dt=dt, stepper=stepper, aliased_fraction=0)
 nothing # hide
 
 # and define some shortcuts

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -46,9 +46,9 @@ nothing # hide
 
 # ## Physical parameters
 
-  L = 2π        # domain size
- nν = 4
-  ν = 1e-19
+ L = 2π        # domain size
+ ν = 1e-19     # hyper-viscosity coefficient
+nν = 4         # hyper-viscosity order
 nothing # hide
 
 


### PR DESCRIPTION
This PR removes the dealiasing from some of the examples for better visualizations.
(Dealiasing was creating artifacts in the vorticity fields.)