### PR TITLE
Optimize 2-layer configs for `MultiLayerQG`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ authors = ["Navid C. Constantinou <navidcy@gmail.com>", "Gregory L. Wagner <wagn
 version = "0.13.1"
 
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ authors = ["Navid C. Constantinou <navidcy@gmail.com>", "Gregory L. Wagner <wagn
 version = "0.13.1"
 
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -30,8 +29,9 @@ StaticArrays = "^0.12, ^1"
 julia = "^1.5"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Coverage"]
+test = ["Test", "Coverage", "BenchmarkTools"]

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "GeophysicalFlows"
 uuid = "44ee3b1c-bc02-53fa-8355-8e347616e15e"
 license = "MIT"
 authors = ["Navid C. Constantinou <navidcy@gmail.com>", "Gregory L. Wagner <wagner.greg@gmail.com>", "and co-contributors"]
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -939,7 +939,7 @@ function energies(vars, params, grid, sol)
 
   return KE, PE
 end
-
+#=
 function energies(vars, params::TwoLayerParams, grid, sol)
   nlayers = numberoflayers(params)
   KE, PE = zeros(nlayers), zeros(nlayers-1)
@@ -960,8 +960,7 @@ function energies(vars, params::TwoLayerParams, grid, sol)
   
   return KE, PE
 end
-
-
+=#
 function energies(vars, params::SingleLayerParams, grid, sol)
   @. vars.qh = sol
   streamfunctionfrompv!(vars.ψh, vars.qh, params, grid)
@@ -1018,7 +1017,7 @@ function fluxes(vars, params, grid, sol)
 
   return lateralfluxes, verticalfluxes
 end
-
+#=
 function fluxes(vars, params::TwoLayerParams, grid, sol)
   nlayers = numberoflayers(params)
   
@@ -1045,7 +1044,7 @@ function fluxes(vars, params::TwoLayerParams, grid, sol)
 
   return lateralfluxes, verticalfluxes
 end
-
+=#
 function fluxes(vars, params::SingleLayerParams, grid, sol)
   updatevars!(vars, params, grid, sol)
 

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -108,7 +108,7 @@ function Problem(nlayers::Int,                        # number of fluid layers
                        T = Float64)
 
   if dev == GPU() && nlayers > 2
-    @warn """MultiLayerQG module not well optimized on the GPU yet for configurations with
+    @warn """MultiLayerQG module is not optimized on the GPU yet for configurations with
     3 fluid layers or more!
     
     See issues on Github at https://github.com/FourierFlows/GeophysicalFlows.jl/issues/112

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -611,7 +611,7 @@ function streamfunctionfrompv!(ψh, qh, params::TwoLayerParams, grid)
   @views @. ψh[:, :, 2] = - grid.Krsq * q2h - f₀^2 / g′ * (q1h / H₂ + q2h / H₁)
   
   for j in 1:2
-    @. ψh[:, :, j] *= grid.invKrsq / (grid.Krsq + f₀^2 / g′ * (H₁ + H₂) / (H₁ * H₂))
+    @views @. ψh[:, :, j] *= grid.invKrsq / (grid.Krsq + f₀^2 / g′ * (H₁ + H₂) / (H₁ * H₂))
   end
 
   return nothing

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -939,7 +939,7 @@ function energies(vars, params, grid, sol)
 
   return KE, PE
 end
-#=
+
 function energies(vars, params::TwoLayerParams, grid, sol)
   nlayers = numberoflayers(params)
   KE, PE = zeros(nlayers), zeros(nlayers-1)
@@ -960,7 +960,7 @@ function energies(vars, params::TwoLayerParams, grid, sol)
   
   return KE, PE
 end
-=#
+
 function energies(vars, params::SingleLayerParams, grid, sol)
   @. vars.qh = sol
   streamfunctionfrompv!(vars.ψh, vars.qh, params, grid)
@@ -1017,7 +1017,7 @@ function fluxes(vars, params, grid, sol)
 
   return lateralfluxes, verticalfluxes
 end
-#=
+
 function fluxes(vars, params::TwoLayerParams, grid, sol)
   nlayers = numberoflayers(params)
   
@@ -1044,7 +1044,7 @@ function fluxes(vars, params::TwoLayerParams, grid, sol)
 
   return lateralfluxes, verticalfluxes
 end
-=#
+
 function fluxes(vars, params::SingleLayerParams, grid, sol)
   updatevars!(vars, params, grid, sol)
 

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -986,7 +986,8 @@ function fluxes(vars, params, grid, sol)
   @. ∂u∂yh = im * grid.l * vars.uh
   invtransform!(∂u∂y, ∂u∂yh, params)
 
-  lateralfluxes = (sum(@. params.H * params.U * vars.v * ∂u∂y; dims=(1, 2)))[1, 1, :]
+  lateralfluxes = (sum(@. params.U * vars.v * ∂u∂y; dims=(1, 2)))[1, 1, :]
+  @. lateralfluxes *= params.H
   lateralfluxes *= grid.dx * grid.dy / (grid.Lx * grid.Ly * sum(params.H))
 
   for j = 1:nlayers-1

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -233,7 +233,7 @@ struct TwoLayerParams{T, Aphys3D, Aphys2D, Trfft} <: AbstractParams
          ρ :: Aphys3D
     "tuple with rest height of each fluid layer"
          H :: Tuple
-    "array with imposed constant zonal flow U(y) in each fluid layer"
+   "array with imposed constant zonal flow U(y) in each fluid layer"
          U :: Aphys3D
     "array containing topographic PV"
        eta :: Aphys2D
@@ -603,15 +603,15 @@ where ``Δ = k² [k² + f₀² (H₁ + H₂) / (g′ H₁ H₂)]``.
 on the GPU.)
 """
 function streamfunctionfrompv!(ψh, qh, params::TwoLayerParams, grid)
-  f₀, g′, H₁, H₁ = params.f₀, params.g′, params.H[1], params.H[2]
+  f₀, g′, H₁, H₂ = params.f₀, params.g′, params.H[1], params.H[2]
   
   q1h, q2h = qh[:, :, 1], qh[:, :, 2]
 
-  @. ψh[:, :, 1] = - grid.Krsq * q1h - f₀^2 / g′ * (q1h / H₁ + q2h / H₁)
-  @. ψh[:, :, 2] = - grid.Krsq * q2h - f₀^2 / g′ * (q1h / H₁ + q2h / H₁)
+  @. ψh[:, :, 1] = - grid.Krsq * q1h - f₀^2 / g′ * (q1h / H₂ + q2h / H₁)
+  @. ψh[:, :, 2] = - grid.Krsq * q2h - f₀^2 / g′ * (q1h / H₂ + q2h / H₁)
   
   for j in 1:2
-    @. ψh[:, :, j] *= grid.invKrsq / (grid.Krsq + f₀^2 / g′ * (H₁ + H₁) / (H₁ * H₁))
+    @. ψh[:, :, j] *= grid.invKrsq / (grid.Krsq + f₀^2 / g′ * (H₁ + H₂) / (H₁ * H₂))
   end
 
   return nothing

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -549,7 +549,7 @@ on the GPU.)
 function pvfromstreamfunction!(qh, ψh, params::TwoLayerParams, grid)
   f₀, g′, H₁, H₂ = params.f₀, params.g′, params.H[1], params.H[2]
   
-  ψ1h, ψ2h = ψh[:, :, 1], ψh[:, :, 2]
+  ψ1h, ψ2h = view(ψh, :, :, 1), view(ψh, :, :, 2)
 
   @. qh[:, :, 1] = - grid.Krsq * ψ1h + f₀^2 / (g′ * H₁) * (ψ2h - ψ1h)
   @. qh[:, :, 2] = - grid.Krsq * ψ2h + f₀^2 / (g′ * H₂) * (ψ1h - ψ2h)

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -551,8 +551,8 @@ function pvfromstreamfunction!(qh, ψh, params::TwoLayerParams, grid)
   
   ψ1h, ψ2h = view(ψh, :, :, 1), view(ψh, :, :, 2)
 
-  @. qh[:, :, 1] = - grid.Krsq * ψ1h + f₀^2 / (g′ * H₁) * (ψ2h - ψ1h)
-  @. qh[:, :, 2] = - grid.Krsq * ψ2h + f₀^2 / (g′ * H₂) * (ψ1h - ψ2h)
+  @views @. qh[:, :, 1] = - grid.Krsq * ψ1h + f₀^2 / (g′ * H₁) * (ψ2h - ψ1h)
+  @views @. qh[:, :, 2] = - grid.Krsq * ψ2h + f₀^2 / (g′ * H₂) * (ψ1h - ψ2h)
   
   return nothing
 end
@@ -605,10 +605,10 @@ on the GPU.)
 function streamfunctionfrompv!(ψh, qh, params::TwoLayerParams, grid)
   f₀, g′, H₁, H₂ = params.f₀, params.g′, params.H[1], params.H[2]
   
-  q1h, q2h = qh[:, :, 1], qh[:, :, 2]
+  q1h, q2h = view(qh, :, :, 1), view(qh, :, :, 2)
 
-  @. ψh[:, :, 1] = - grid.Krsq * q1h - f₀^2 / g′ * (q1h / H₂ + q2h / H₁)
-  @. ψh[:, :, 2] = - grid.Krsq * q2h - f₀^2 / g′ * (q1h / H₂ + q2h / H₁)
+  @views @. ψh[:, :, 1] = - grid.Krsq * q1h - f₀^2 / g′ * (q1h / H₂ + q2h / H₁)
+  @views @. ψh[:, :, 2] = - grid.Krsq * q2h - f₀^2 / g′ * (q1h / H₂ + q2h / H₁)
   
   for j in 1:2
     @. ψh[:, :, j] *= grid.invKrsq / (grid.Krsq + f₀^2 / g′ * (H₁ + H₂) / (H₁ * H₂))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,15 +24,16 @@ const rtol_multilayerqg = 1e-13 # tolerance for multilayerqg forcing tests
 const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
 
 using BenchmarkTools
-for dev = devices
-  @show dev
 
-  prob2 = MultiLayerQG.Problem(2, dev);
-  @show @btime stepforward!(prob2)
+dev = GPU()
 
-  prob3 = MultiLayerQG.Problem(3, dev);
-  @show @btime stepforward!(prob3)
-end
+@show nlayers = 2
+prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
+@btime stepforward!(prob)
+
+@show nlayers = 3
+prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
+@btime stepforward!(prob)
 
 
 # Run tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,17 +26,49 @@ const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
 
 using BenchmarkTools
 
-dev = GPU()
+@show dev = CPU()
 
 @show nlayers = 2
 prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-@btime stepforward!(prob)
+energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
+fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
+
+@btime stepforward!(prob, 10)
+@btime stepforward!(prob, [energies], 10)
+@btime stepforward!(prob, [fluxes], 10)
 
 @show nlayers = 3
 prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-@btime stepforward!(prob)
+energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
+fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
 
+@btime stepforward!(prob, 10)
+@btime stepforward!(prob, [energies], 10)
+@btime stepforward!(prob, [fluxes], 10)
 
+#=
+@show dev = GPU()
+
+@show nlayers = 2
+prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
+energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
+fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
+
+@btime stepforward!(prob, 10)
+@btime stepforward!(prob, [energies], 10)
+@btime stepforward!(prob, [fluxes], 10)
+
+@show nlayers = 3
+prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
+energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
+fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
+
+@btime stepforward!(prob, 10)
+@btime stepforward!(prob, [energies], 10)
+@btime stepforward!(prob, [fluxes], 10)
+=#
+
+#=
 # Run tests
 testtime = @elapsed begin
 for dev in devices
@@ -150,3 +182,4 @@ end
 end # time
 
 println("Total test time: ", testtime)
+=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
 @btime stepforward!(prob, [energies], 10)
 @btime stepforward!(prob, [fluxes], 10)
 
-#=
+
 @show dev = GPU()
 
 @show nlayers = 2
@@ -66,7 +66,7 @@ fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
 @btime stepforward!(prob, 10)
 @btime stepforward!(prob, [energies], 10)
 @btime stepforward!(prob, [fluxes], 10)
-=#
+
 
 #=
 # Run tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,8 @@ const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
 
 using BenchmarkTools
 
+@show CUDA.has_cuda()
+
 @show dev = CPU()
 
 @show nlayers = 2
@@ -33,24 +35,24 @@ prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
 energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
 fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
 
-println("no diags")
-@benchmark stepforward!(prob, 10)
-println("energies")
-@benchmark stepforward!(prob, [energies], 10)
-println("fluxes")
-@benchmark stepforward!(prob, [fluxes], 10)
+@info "no diags"
+@btime stepforward!(prob, 10)
+@info "energies"
+@btime stepforward!(prob, [energies], 10)
+@info "fluxes"
+@btime stepforward!(prob, [fluxes], 10)
 
 @show nlayers = 3
 prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
 energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
 fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
 
-println("no diags")
-@benchmark stepforward!(prob, 10)
-println("energies")
-@benchmark stepforward!(prob, [energies], 10)
-println("fluxes")
-@benchmark stepforward!(prob, [fluxes], 10)
+@info "no diags"
+@btime stepforward!(prob, 10)
+@info "energies"
+@btime stepforward!(prob, [energies], 10)
+@info "fluxes"
+@btime stepforward!(prob, [fluxes], 10)
 
 
 @show dev = GPU()
@@ -60,24 +62,24 @@ prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
 energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
 fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
 
-println("no diags")
-@benchmark CUDA.@sync stepforward!(prob, 10)
-println("energies")
-@benchmark CUDA.@sync stepforward!(prob, [energies], 10)
-println("fluxes")
-@benchmark CUDA.@sync stepforward!(prob, [fluxes], 10)
+@info "no diags"
+@btime CUDA.@sync stepforward!(prob, 10)
+@info "energies"
+@btime CUDA.@sync stepforward!(prob, [energies], 10)
+@info "fluxes"
+@btime CUDA.@sync stepforward!(prob, [fluxes], 10)
 
 @show nlayers = 3
 prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
 energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
 fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
 
-println("no diags")
-@benchmark CUDA.@sync stepforward!(prob, 10)
-println("energies")
-@benchmark CUDA.@sync stepforward!(prob, [energies], 10)
-println("fluxes")
-@benchmark CUDA.@sync stepforward!(prob, [fluxes], 10)
+@info "no diags"
+@btime CUDA.@sync stepforward!(prob, 10)
+@info "energies"
+@btime CUDA.@sync stepforward!(prob, [energies], 10)
+@info "fluxes"
+@btime CUDA.@sync stepforward!(prob, [fluxes], 10)
 
 #=
 # Run tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,3 +137,14 @@ end
 end # time
 
 println("Total test time: ", testtime)
+
+using Pkg; Pkg.add("BenchmarkTools"); using GeophysicalFlows, BenchmarkTools;
+for dev = devices
+  @show dev
+
+  prob2 = MultiLayerQG.Problem(2, dev);
+  @show @btime stepforward!(prob2)
+
+  prob3 = MultiLayerQG.Problem(3, dev);
+  @show @btime stepforward!(prob3)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,19 +54,24 @@ prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
 energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
 fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
 
-@btime stepforward!(prob, 10)
-@btime stepforward!(prob, [energies], 10)
-@btime stepforward!(prob, [fluxes], 10)
+println("no diags")
+@benchmark stepforward!(prob, 10)
+println("energies")
+@benchmark stepforward!(prob, [energies], 10)
+println("fluxes")
+@benchmark stepforward!(prob, [fluxes], 10)
 
 @show nlayers = 3
 prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
 energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
 fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
 
-@btime stepforward!(prob, 10)
-@btime stepforward!(prob, [energies], 10)
-@btime stepforward!(prob, [fluxes], 10)
-
+println("no diags")
+@benchmark CUDA.@sync stepforward!(prob, 10)
+println("energies")
+@benchmark CUDA.@sync stepforward!(prob, [energies], 10)
+println("fluxes")
+@benchmark CUDA.@sync stepforward!(prob, [fluxes], 10)
 
 #=
 # Run tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,19 +23,17 @@ const rtol_singlelayerqg = 1e-13 # tolerance for singlelayerqg forcing tests
 const rtol_multilayerqg = 1e-13 # tolerance for multilayerqg forcing tests
 const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
 
-if CUDA.has_cuda() begin
-  using BenchmarkTools
+using BenchmarkTools
 
-  dev = GPU()
-  
-  @show nlayers = 2
-  prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-  @btime stepforward!(prob)
-  
-  @show nlayers = 3
-  prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-  @btime stepforward!(prob)    
-end
+dev = GPU()
+
+@show nlayers = 2
+prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
+@btime stepforward!(prob)
+
+@show nlayers = 3
+prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
+@btime stepforward!(prob)    
 
 # Run tests
 testtime = @elapsed begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,18 +23,19 @@ const rtol_singlelayerqg = 1e-13 # tolerance for singlelayerqg forcing tests
 const rtol_multilayerqg = 1e-13 # tolerance for multilayerqg forcing tests
 const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
 
-using BenchmarkTools
+if CUDA.has_cuda() begin
+  using BenchmarkTools
 
-dev = GPU()
-
-@show nlayers = 2
-prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-@btime stepforward!(prob)
-
-@show nlayers = 3
-prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-@btime stepforward!(prob)
-
+  dev = GPU()
+  
+  @show nlayers = 2
+  prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
+  @btime stepforward!(prob)
+  
+  @show nlayers = 3
+  prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
+  @btime stepforward!(prob)    
+end
 
 # Run tests
 testtime = @elapsed begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,17 @@ const rtol_singlelayerqg = 1e-13 # tolerance for singlelayerqg forcing tests
 const rtol_multilayerqg = 1e-13 # tolerance for multilayerqg forcing tests
 const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
 
+using Pkg; Pkg.add("BenchmarkTools"); using GeophysicalFlows, BenchmarkTools;
+for dev = devices
+  @show dev
+
+  prob2 = MultiLayerQG.Problem(2, dev);
+  @show @btime stepforward!(prob2)
+
+  prob3 = MultiLayerQG.Problem(3, dev);
+  @show @btime stepforward!(prob3)
+end
+
 
 # Run tests
 testtime = @elapsed begin
@@ -137,14 +148,3 @@ end
 end # time
 
 println("Total test time: ", testtime)
-
-using Pkg; Pkg.add("BenchmarkTools"); using GeophysicalFlows, BenchmarkTools;
-for dev = devices
-  @show dev
-
-  prob2 = MultiLayerQG.Problem(2, dev);
-  @show @btime stepforward!(prob2)
-
-  prob3 = MultiLayerQG.Problem(3, dev);
-  @show @btime stepforward!(prob3)
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,65 +23,6 @@ const rtol_singlelayerqg = 1e-13 # tolerance for singlelayerqg forcing tests
 const rtol_multilayerqg = 1e-13 # tolerance for multilayerqg forcing tests
 const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
 
-
-using BenchmarkTools
-
-@show CUDA.has_cuda()
-
-@show dev = CPU()
-
-@show nlayers = 2
-prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
-fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
-
-@info "no diags"
-@btime stepforward!(prob, 10)
-@info "energies"
-@btime stepforward!(prob, [energies], 10)
-@info "fluxes"
-@btime stepforward!(prob, [fluxes], 10)
-
-@show nlayers = 3
-prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
-fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
-
-@info "no diags"
-@btime stepforward!(prob, 10)
-@info "energies"
-@btime stepforward!(prob, [energies], 10)
-@info "fluxes"
-@btime stepforward!(prob, [fluxes], 10)
-
-
-@show dev = GPU()
-
-@show nlayers = 2
-prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
-fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
-
-@info "no diags"
-@btime CUDA.@sync stepforward!(prob, 10)
-@info "energies"
-@btime CUDA.@sync stepforward!(prob, [energies], 10)
-@info "fluxes"
-@btime CUDA.@sync stepforward!(prob, [fluxes], 10)
-
-@show nlayers = 3
-prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
-fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
-
-@info "no diags"
-@btime CUDA.@sync stepforward!(prob, 10)
-@info "energies"
-@btime CUDA.@sync stepforward!(prob, [energies], 10)
-@info "fluxes"
-@btime CUDA.@sync stepforward!(prob, [fluxes], 10)
-
-#=
 # Run tests
 testtime = @elapsed begin
 for dev in devices
@@ -195,4 +136,3 @@ end
 end # time
 
 println("Total test time: ", testtime)
-=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ const rtol_singlelayerqg = 1e-13 # tolerance for singlelayerqg forcing tests
 const rtol_multilayerqg = 1e-13 # tolerance for multilayerqg forcing tests
 const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
 
+
 using BenchmarkTools
 
 dev = GPU()
@@ -33,7 +34,8 @@ prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
 
 @show nlayers = 3
 prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-@btime stepforward!(prob)    
+@btime stepforward!(prob)
+
 
 # Run tests
 testtime = @elapsed begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,23 +33,14 @@ prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
 energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
 fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
 
-@btime stepforward!(prob, 10)
-@btime stepforward!(prob, [energies], 10)
-@btime stepforward!(prob, [fluxes], 10)
+println("no diags")
+@benchmark stepforward!(prob, 10)
+println("energies")
+@benchmark stepforward!(prob, [energies], 10)
+println("fluxes")
+@benchmark stepforward!(prob, [fluxes], 10)
 
 @show nlayers = 3
-prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
-energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
-fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
-
-@btime stepforward!(prob, 10)
-@btime stepforward!(prob, [energies], 10)
-@btime stepforward!(prob, [fluxes], 10)
-
-
-@show dev = GPU()
-
-@show nlayers = 2
 prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
 energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
 fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
@@ -60,6 +51,21 @@ println("energies")
 @benchmark stepforward!(prob, [energies], 10)
 println("fluxes")
 @benchmark stepforward!(prob, [fluxes], 10)
+
+
+@show dev = GPU()
+
+@show nlayers = 2
+prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)
+energies = Diagnostic(MultiLayerQG.energies, prob, freq=1, nsteps=10)
+fluxes = Diagnostic(MultiLayerQG.fluxes, prob, freq=1, nsteps=10)
+
+println("no diags")
+@benchmark CUDA.@sync stepforward!(prob, 10)
+println("energies")
+@benchmark CUDA.@sync stepforward!(prob, [energies], 10)
+println("fluxes")
+@benchmark CUDA.@sync stepforward!(prob, [fluxes], 10)
 
 @show nlayers = 3
 prob = GeophysicalFlows.MultiLayerQG.Problem(nlayers, dev)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ const rtol_singlelayerqg = 1e-13 # tolerance for singlelayerqg forcing tests
 const rtol_multilayerqg = 1e-13 # tolerance for multilayerqg forcing tests
 const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
 
-using Pkg; Pkg.add("BenchmarkTools"); using GeophysicalFlows, BenchmarkTools;
+using BenchmarkTools
 for dev = devices
   @show dev
 


### PR DESCRIPTION
This PR attempts to optimize the 2-layer configuration of `MultiLayerQG` module by hard-coding the PV-streamfunction relationships. To do so we create a `TwoLayerParams <: AbstractParams` and then use this type to add methods in both `streamfunctionfrompv!` and `pvfromstreamfunction!` functions that include the hard-coded PV-streamfunction relationships for 2-layer configurations.

Some benchmarks for 2- and 3-layer configs with `nx = ny = 128`:

with `nlayers=2`

**before this PR**
```julia
julia> using GeophysicalFlows, BenchmarkTools

julia> nlayers = 2; prob = MultiLayerQG.Problem(nlayers, GPU()); @btime stepforward!(prob)
3.317 s (700757 allocations: 114.42 MiB)
```

**after this PR**
```julia
julia> using GeophysicalFlows, BenchmarkTools

julia> nlayers = 2; prob = MultiLayerQG.Problem(nlayers, GPU()); @btime stepforward!(prob)
1.923 ms (3385 allocations: 321.58 KiB)
```



with `nlayers=3` (shouldn't be affected by this PR)

**before this PR**
```julia
julia> using GeophysicalFlows, BenchmarkTools

julia> nlayers = 3; prob = MultiLayerQG.Problem(nlayers, GPU()); @btime stepforward!(prob)
6.194 s (1299797 allocations: 213.44 MiB)
```

**after this PR**
```julia
julia> using GeophysicalFlows, BenchmarkTools

julia> nlayers = 3; prob = MultiLayerQG.Problem(nlayers, GPU()); @btime stepforward!(prob)
5.641 s (1299797 allocations: 213.44 MiB)
```

1650-fold faster for 2-layer config. We'll take that as an improvement. (Possibly even faster for higher grid resolution!)

Closes #267.