### PR TITLE
Support SpecialFunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ FFTW = "^1"
 FourierFlows = "^0.7.1"
 JLD2 = "^0.1, ^0.2, ^0.3, ^0.4"
 Reexport = "^0.2, ^1"
-SpecialFunctions = "^0.10, ^1"
+SpecialFunctions = "^0.10, ^1, 2"
 StaticArrays = "^0.12, ^1"
 julia = "^1.5"
 


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` this shouldn't affect you.