### PR TITLE
Use FourierFlows v0.9.0 and avoid CUDA v3.7.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-CUDA = "^1, ^2.4.2, 3.0.0 - 3.6.4"
+CUDA = "^1, ^2.4.2, 3.0.0 - 3.6.4, ^3.7.1"
 DocStringExtensions = "^0.8"
 FFTW = "^1"
 FourierFlows = "^0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -18,10 +18,10 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-CUDA = "^1, ^2.4.2, 3.0.0 - 3.3.6"
+CUDA = "^1, ^2.4.2, 3.0.0 - 3.6.4"
 DocStringExtensions = "^0.8"
 FFTW = "^1"
-FourierFlows = "^0.7.1, 0.8"
+FourierFlows = "^0.9"
 JLD2 = "^0.1, ^0.2, ^0.3, ^0.4"
 Reexport = "^0.2, ^1"
 SpecialFunctions = "^0.10, ^1, 2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,6 +6,6 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-CUDA = "^1, ^2.4.2, 3.0.0 - 3.3.6"
+CUDA = "^1, ^2.4.2, 3.0.0 - 3.6.4, ^3.7.1"
 Literate = "≥2.9.0"
 Plots = "1.10.1 - 1.21.3"

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -18,7 +18,7 @@
 # ## Let's begin
 # Let's load `GeophysicalFlows.jl` and some other needed packages.
 
-using GeophysicalFlows, Random, Printf, Plots
+using GeophysicalFlows, CUDA, Random, Printf, Plots
 using Statistics: mean
 parsevalsum = FourierFlows.parsevalsum
 

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -17,7 +17,7 @@
 # ## Let's begin
 # Let's load `GeophysicalFlows.jl` and some other needed packages.
 #
-using GeophysicalFlows, Random, Printf, Plots
+using GeophysicalFlows, CUDA, Random, Printf, Plots
 
 using Statistics: mean
 parsevalsum = FourierFlows.parsevalsum

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -18,7 +18,7 @@
 # ## Let's begin
 # Let's load `GeophysicalFlows.jl` and some other needed packages.
 #
-using GeophysicalFlows, Random, Printf, Plots
+using GeophysicalFlows, CUDA, Random, Printf, Plots
 parsevalsum = FourierFlows.parsevalsum
 
 # ## Choosing a device: CPU or GPU

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -20,7 +20,7 @@
 # ## Let's begin
 # Let's load `GeophysicalFlows.jl` and some other needed packages.
 #
-using GeophysicalFlows, Random, Printf, Plots
+using GeophysicalFlows, CUDA, Random, Printf, Plots
 parsevalsum = FourierFlows.parsevalsum
 
 # ## Choosing a device: CPU or GPU

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ using FourierFlows: parsevalsum
 using GeophysicalFlows: lambdipole, peakedisotropicspectrum
 
 # the devices on which tests will run
-devices = CUDA.has_cuda() ? (CPU(), GPU()) : (CPU(),)
+devices = CUDA.functional() ? (CPU(), GPU()) : (CPU(),)
 
 const rtol_lambdipole = 1e-2 # tolerance for lamb dipole tests
 const rtol_twodnavierstokes = 1e-13 # tolerance for twodnavierstokes forcing tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using
+  CUDA,
   GeophysicalFlows,
   Statistics,
   Random,


### PR DESCRIPTION
CUDA v3.7.0 had a bug and was precluding `mul!()` from working for Fourier transforms. See https://github.com/FourierFlows/FourierFlows.jl/pull/310