### PR TITLE
Bit of cleanup and using `views` in `MultiLayerQG` module

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v3

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,5 +7,6 @@ Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
+CairoMakie = "< 0.10.5"
 CUDA = "1, 2.4.2, 3.0.0 - 3.6.4, 3.7.1, 4"
 Literate = "≥2.9.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,11 +2,10 @@
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-CUDA = "^1, ^2.4.2, 3.0.0 - 3.6.4, ^3.7.1"
+CUDA = "1, 2.4.2, 3.0.0 - 3.6.4, 3.7.1, 4"
 Literate = "≥2.9.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,10 +29,13 @@ examples = [
 for example in examples
   withenv("GITHUB_REPOSITORY" => "FourierFlows/GeophysicalFlowsDocumentation") do
     example_filepath = joinpath(EXAMPLES_DIR, example)
-    @time Literate.markdown(example_filepath, OUTPUT_DIR;
-    flavor = Literate.DocumenterFlavor(), execute = true)
+    withenv("JULIA_DEBUG" => "Literate") do
+      Literate.markdown(example_filepath, OUTPUT_DIR;
+                        flavor = Literate.DocumenterFlavor(), execute = true)
+    end
+  end
 end
-end
+
 
 #####
 ##### Build and deploy docs

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,12 +22,14 @@ examples = [
   "surfaceqg_decaying.jl",
 ]
 
+
 for example in examples
   withenv("GITHUB_REPOSITORY" => "FourierFlows/GeophysicalFlowsDocumentation") do
     example_filepath = joinpath(EXAMPLES_DIR, example)
-    Literate.markdown(example_filepath, OUTPUT_DIR; flavor = Literate.DocumenterFlavor())
-    Literate.notebook(example_filepath, OUTPUT_DIR)
-    Literate.script(example_filepath, OUTPUT_DIR)
+    withenv("JULIA_DEBUG" => "Literate") do
+        Literate.markdown(example_filepath, OUTPUT_DIR;
+                          flavor = Literate.DocumenterFlavor(), execute = true)
+    end
   end
 end
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,9 @@
-using
-  Documenter,
-  Literate,
-  CairoMakie,   # to not capture precompilation output
-  GeophysicalFlows,
-  Glob
+using Documenter, Literate
+
+using CairoMakie # to avoid capturing precompilation output by Literate
+CairoMakie.activate!(type = "svg")
+
+using GeophysicalFlows
 
 #####
 ##### Generate literated examples
@@ -38,10 +38,6 @@ end
 ##### Build and deploy docs
 #####
 
-# Set up a timer to print a space ' ' every 240 seconds. This is to avoid CI machines
-# timing out when building demanding Literate.jl examples.
-Timer(t -> println(" "), 0, interval=240)
-
 format = Documenter.HTML(
   collapselevel = 2,
      prettyurls = get(ENV, "CI", nothing) == "true",
@@ -50,11 +46,11 @@ format = Documenter.HTML(
 
 makedocs(
  modules = [GeophysicalFlows],
- doctest = false,
+ doctest = true,
    clean = true,
 checkdocs = :all,
   format = format,
- authors = "Navid C. Constantinou and Gregory L. Wagner",
+ authors = "Navid C. Constantinou, Gregory L. Wagner, and contributors",
 sitename = "GeophysicalFlows.jl",
    pages = Any[
             "Home"    => "index.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using Documenter, Literate
 
 using CairoMakie
-CairoMakie.activate!(type = "svg")
+# CairoMakie.activate!(type = "svg")
 
 using GeophysicalFlows
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,8 +29,6 @@ for example in examples
     withenv("JULIA_DEBUG" => "Literate") do
       Literate.markdown(example_filepath, OUTPUT_DIR;
                         flavor = Literate.DocumenterFlavor(), execute = true)
-      Literate.notebook(example_filepath, OUTPUT_DIR, execute = false)
-      Literate.script(example_filepath, OUTPUT_DIR)
     end
   end
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,4 @@
-using Documenter, Literate
-
-using CairoMakie # to avoid capturing precompilation output by Literate
-CairoMakie.activate!(type = "svg")
+using Documenter, Literate, CairoMakie
 
 using GeophysicalFlows
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,8 +27,10 @@ for example in examples
   withenv("GITHUB_REPOSITORY" => "FourierFlows/GeophysicalFlowsDocumentation") do
     example_filepath = joinpath(EXAMPLES_DIR, example)
     withenv("JULIA_DEBUG" => "Literate") do
-        Literate.markdown(example_filepath, OUTPUT_DIR;
-                          flavor = Literate.DocumenterFlavor(), execute = true)
+      Literate.markdown(example_filepath, OUTPUT_DIR;
+                        flavor = Literate.DocumenterFlavor(), execute = true)
+      Literate.notebook(example_filepath, OUTPUT_DIR, execute = false)
+      Literate.script(example_filepath, OUTPUT_DIR)
     end
   end
 end

--- a/docs/src/stochastic_forcing.md
+++ b/docs/src/stochastic_forcing.md
@@ -321,7 +321,7 @@ hl3 = lines!(ax, μ * t, E_str[:, 1];
 
 Legend(fig[1, 2], [hl1, hl2, hl3], ["½ xₜ²", "Eₜ (Ito)", "Eₜ (Stratonovich)"])
 
-save("assets/energy_comparison.svg", fig); nothing # hide
+save("assets/energy_comparison.svg", fig); nothing #hide
 ```
 
 ![energy_comparison](assets/energy_comparison.svg)
@@ -378,7 +378,7 @@ hl3 = lines!(ax2, μ * t[1:nsteps-1], dEdt_theory[1:nsteps-1];
 Legend(fig[2, 2], [hl1, hl2, hl3],
                   ["numerical 𝖽⟨E⟩/𝖽t", "⟨work - dissipation⟩", "theoretical 𝖽⟨E⟩/𝖽t"])
 
-save("assets/energy_budgets_Ito.svg", fig); nothing # hide
+save("assets/energy_budgets_Ito.svg", fig); nothing #hide
 ```
 
 ![energy_budgets_Ito](assets/energy_budgets_Ito.svg)
@@ -423,7 +423,7 @@ hl3 = lines!(ax2, μ * t[1:nsteps-1], dEdt_theory[1:nsteps-1];
 Legend(fig[2, 2], [hl1, hl2, hl3],
                   ["numerical 𝖽⟨E⟩/𝖽t", "⟨work - dissipation⟩", "theoretical 𝖽⟨E⟩/𝖽t"])
 
-save("assets/energy_budgets_Stratonovich.svg", fig); nothing # hide
+save("assets/energy_budgets_Stratonovich.svg", fig); nothing #hide
 ```
 
 ![energy_budgets_Stratonovich](assets/energy_budgets_Stratonovich.svg)

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -1,7 +1,5 @@
 # # [Quasi-Linear forced-dissipative barotropic QG beta-plane turbulence](@id barotropicqgql_betaforced_example)
 #
-#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/literated/barotropicqgql_betaforced.ipynb).
-#
 # A simulation of forced-dissipative barotropic quasi-geostrophic turbulence on 
 # a beta plane under the *quasi-linear approximation*. The dynamics include 
 # linear drag and stochastic excitation.

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -24,12 +24,12 @@ using Statistics: mean
 
 parsevalsum = FourierFlows.parsevalsum
 record = CairoMakie.record                # disambiguate between CairoMakie.record and CUDA.record
-nothing # hide
+nothing #hide
 
 # ## Choosing a device: CPU or GPU
 
 dev = CPU()     # Device (CPU/GPU)
-nothing # hide
+nothing #hide
 
 
 # ## Numerical parameters and time-stepping parameters
@@ -39,7 +39,7 @@ stepper = "FilteredRK4"  # timestepper
      dt = 0.05           # timestep
  nsteps = 8000           # total number of time-steps
  nsubs  = 10             # number of time-steps for intermediate logging/plotting (nsteps must be multiple of nsubs)
-nothing # hide
+nothing #hide
 
 
 # ## Physical parameters
@@ -47,7 +47,7 @@ nothing # hide
 L = 2π        # domain size
 β = 10.0      # planetary PV gradient
 μ = 0.01      # bottom drag
-nothing # hide
+nothing #hide
  
 
 # ## Forcing
@@ -72,12 +72,12 @@ forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2
 
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
 @. forcing_spectrum *= ε/ε0       # normalize forcing to inject energy at rate ε
-nothing # hide
+nothing #hide
 
 
 # We reset of the random number generator for reproducibility
 if dev==CPU(); Random.seed!(1234); else; CUDA.seed!(1234); end
-nothing # hide
+nothing #hide
 
 
 # Next we construct function `calcF!` that computes a forcing realization every timestep.
@@ -91,7 +91,7 @@ function calcF!(Fh, sol, t, clock, vars, params, grid)
 
   return nothing
 end
-nothing # hide
+nothing #hide
 
 
 # ## Problem setup
@@ -102,13 +102,13 @@ nothing # hide
 # Thus, we choose not to do any dealiasing by providing `aliased_fraction=0`.
 prob = BarotropicQGQL.Problem(dev; nx=n, Lx=L, β, μ, dt, stepper, 
                               calcF=calcF!, stochastic=true, aliased_fraction=0)
-nothing # hide
+nothing #hide
 
 # and define some shortcuts.
 sol, clock, vars, params, grid = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 x,  y  = grid.x, grid.y
 Lx, Ly = grid.Lx, grid.Ly
-nothing # hide
+nothing #hide
 
 
 # First let's see how a forcing realization looks like. Note that when plotting, we decorate 
@@ -136,24 +136,24 @@ fig
 
 # Our initial condition is simply fluid at rest.
 BarotropicQGQL.set_zeta!(prob, device_array(dev)(zeros(grid.nx, grid.ny)))
-nothing # hide
+nothing #hide
 
 # ## Diagnostics
 
 # Create Diagnostics -- `energy` and `enstrophy` are functions imported at the top.
 E = Diagnostic(BarotropicQGQL.energy, prob; nsteps)
 Z = Diagnostic(BarotropicQGQL.enstrophy, prob; nsteps)
-nothing # hide
+nothing #hide
 
 # We can also define our custom diagnostics via functions.
 zetaMean(prob) = prob.sol[1, :]
 
 zMean = Diagnostic(zetaMean, prob; nsteps, freq=10)  # the zonal-mean vorticity
-nothing # hide
+nothing #hide
 
 # We combile all diags in a list.
 diags = [E, Z, zMean] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
-nothing # hide
+nothing #hide
 
 
 # ## Output
@@ -163,12 +163,12 @@ filepath = "."
 plotpath = "./plots_forcedbetaQLturb"
 plotname = "snapshots"
 filename = joinpath(filepath, "forcedbetaQLturb.jld2")
-nothing # hide
+nothing #hide
 
 # Do some basic file management,
 if isfile(filename); rm(filename); end
 if !isdir(plotpath); mkdir(plotpath); end
-nothing # hide
+nothing #hide
 
 # and then create Output.
 get_sol(prob) = prob.sol # extracts the Fourier-transformed solution
@@ -255,7 +255,7 @@ lines!(axū, 0y, y; linewidth = 1, linestyle=:dash)
 lines!(axE, μt, energy; linewidth = 3)
 lines!(axZ, μt, enstrophy; linewidth = 3, color = :red)
 
-nothing # hide
+nothing #hide
 
 
 # ## Time-stepping the `Problem` forward
@@ -291,7 +291,7 @@ record(fig, "barotropicqgql_betaforced.mp4", frames, framerate = 18) do j
   stepforward!(prob, diags, nsubs)
   BarotropicQGQL.updatevars!(prob)
 end
-nothing # hide
+nothing #hide
 
 # ![](barotropicqgql_betaforced.mp4)
 

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -26,7 +26,7 @@ using Random: seed!
 # ## Choosing a device: CPU or GPU
 
 dev = CPU()     # Device (CPU/GPU)
-nothing # hide
+nothing #hide
 
 
 # ## Numerical parameters and time-stepping parameters
@@ -36,7 +36,7 @@ stepper = "FilteredRK4"  # timestepper
      dt = 2.5e-3         # timestep
  nsteps = 20000          # total number of time-steps
  nsubs  = 50             # number of time-steps for plotting (nsteps must be multiple of nsubs)
-nothing # hide
+nothing #hide
 
 
 # ## Physical parameters
@@ -52,7 +52,7 @@ H = [0.2, 0.8]           # the rest depths of each layer
 U = zeros(nlayers)       # the imposed mean zonal flow in each layer
 U[1] = 1.0
 U[2] = 0.0
-nothing # hide
+nothing #hide
 
 
 # ## Problem setup
@@ -63,12 +63,12 @@ nothing # hide
 
 prob = MultiLayerQG.Problem(nlayers, dev; nx=n, Lx=L, f₀, g, H, ρ, U, μ, β,
                             dt, stepper, aliased_fraction=0)
-nothing # hide
+nothing #hide
 
 # and define some shortcuts.
 sol, clock, params, vars, grid = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 x, y = grid.x, grid.y
-nothing # hide
+nothing #hide
 
 
 # ## Setting initial conditions
@@ -85,7 +85,7 @@ q₀h = prob.timestepper.filter .* rfft(q₀, (1, 2)) # apply rfft  only in dims
 q₀  = irfft(q₀h, grid.nx, (1, 2))                 # apply irfft only in dims=1, 2
 
 MultiLayerQG.set_q!(prob, q₀)
-nothing # hide
+nothing #hide
 
 
 # ## Diagnostics
@@ -93,7 +93,7 @@ nothing # hide
 # Create Diagnostics -- `energies` function is imported at the top.
 E = Diagnostic(MultiLayerQG.energies, prob; nsteps)
 diags = [E] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
-nothing # hide
+nothing #hide
 
 
 # ## Output
@@ -103,12 +103,12 @@ filepath = "."
 plotpath = "./plots_2layer"
 plotname = "snapshots"
 filename = joinpath(filepath, "2layer.jld2")
-nothing # hide
+nothing #hide
 
 # Do some basic file management
 if isfile(filename); rm(filename); end
 if !isdir(plotpath); mkdir(plotpath); end
-nothing # hide
+nothing #hide
 
 # And then create Output
 
@@ -126,7 +126,7 @@ function get_u(prob)
 end
 
 out = Output(prob, filename, (:sol, get_sol), (:u, get_u))
-nothing # hide
+nothing #hide
 
 
 # ## Visualizing the simulation
@@ -258,7 +258,7 @@ record(fig, "multilayerqg_2layer.mp4", frames, framerate = 18) do j
   stepforward!(prob, diags, nsubs)
   MultiLayerQG.updatevars!(prob)
 end
-nothing # hide
+nothing #hide
 
 # ![](multilayerqg_2layer.mp4)
 

--- a/examples/multilayerqg_2layer.jl
+++ b/examples/multilayerqg_2layer.jl
@@ -1,7 +1,5 @@
 # # [Phillips model of Baroclinic Instability](@id multilayerqg_2layer_example)
 #
-#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/literated/multilayerqg_2layer.ipynb).
-#
 # A simulation of the growth of barolinic instability in the Phillips 2-layer model
 # when we impose a vertical mean flow shear as a difference ``\Delta U`` in the
 # imposed, domain-averaged, zonal flow at each layer.

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -1,7 +1,5 @@
 # # [Decaying barotropic QG beta-plane turbulence](@id singlelayerqg_betadecay_example)
 #
-#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/literated/singlelayerqg_betadecay.ipynb).
-# 
 # An example of decaying barotropic quasi-geostrophic turbulence on a beta plane.
 #
 # ## Install dependencies

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -24,7 +24,7 @@ using Statistics: mean
 # ## Choosing a device: CPU or GPU
 
 dev = CPU()     # Device (CPU/GPU)
-nothing # hide
+nothing #hide
 
 
 # ## Numerical parameters and time-stepping parameters
@@ -34,7 +34,7 @@ stepper = "FilteredRK4"  # timestepper
      dt = 0.04           # timestep
  nsteps = 2000           # total number of time-steps
  nsubs  = 20             # number of time-steps for intermediate logging/plotting (nsteps must be multiple of nsubs)
-nothing # hide
+nothing #hide
 
 
 # ## Physical parameters
@@ -42,7 +42,7 @@ nothing # hide
 L = 2π        # domain size
 β = 10.0      # planetary PV gradient
 μ = 0.0       # bottom drag
-nothing # hide
+nothing #hide
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments.
@@ -52,12 +52,12 @@ nothing # hide
 # Thus, we choose not to do any dealiasing by providing `aliased_fraction=0`.
 
 prob = SingleLayerQG.Problem(dev; nx=n, Lx=L, β, μ, dt, stepper, aliased_fraction=0)
-nothing # hide
+nothing #hide
 
 # and define some shortcuts
 sol, clock, vars, params, grid = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 x, y = grid.x, grid.y
-nothing # hide
+nothing #hide
 
 
 # ## Setting initial conditions
@@ -80,7 +80,7 @@ q₀h *= sqrt(E₀ / SingleLayerQG.energy(q₀h, vars, params, grid)) # normaliz
 q₀ = irfft(q₀h, grid.nx)
 
 SingleLayerQG.set_q!(prob, q₀)
-nothing # hide
+nothing #hide
 
 # Let's plot the initial vorticity and streamfunction. Note that when plotting, we decorate 
 # the variable to be plotted with `Array()` to make sure it is brought back on the CPU when 
@@ -116,7 +116,7 @@ fig
 E = Diagnostic(SingleLayerQG.energy, prob; nsteps)
 Z = Diagnostic(SingleLayerQG.enstrophy, prob; nsteps)
 diags = [E, Z] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
-nothing # hide
+nothing #hide
 
 
 # ## Output
@@ -126,17 +126,17 @@ filepath = "."
 plotpath = "./plots_decayingbetaturb"
 plotname = "snapshots"
 filename = joinpath(filepath, "decayingbetaturb.jld2")
-nothing # hide
+nothing #hide
 
 # Do some basic file management,
 if isfile(filename); rm(filename); end
 if !isdir(plotpath); mkdir(plotpath); end
-nothing # hide
+nothing #hide
 
 # and then create Output.
 get_sol(prob) = prob.sol # extracts the Fourier-transformed solution
 out = Output(prob, filename, (:sol, get_sol))
-nothing # hide
+nothing #hide
 
 
 # ## Visualizing the simulation
@@ -223,7 +223,7 @@ record(fig, "singlelayerqg_betadecay.mp4", frames, framerate = 8) do j
   stepforward!(prob, diags, nsubs)
   SingleLayerQG.updatevars!(prob)
 end
-nothing # hide
+nothing #hide
 
 # ![](singlelayerqg_betadecay.mp4)
 

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -24,23 +24,23 @@ using LinearAlgebra: ldiv!
 
 parsevalsum = FourierFlows.parsevalsum
 record = CairoMakie.record                # disambiguate between CairoMakie.record and CUDA.record
-nothing # hide
+nothing #hide
 
 # ## Choosing a device: CPU or GPU
 
 dev = CPU()     # Device (CPU/GPU)
-nothing # hide
+nothing #hide
 
 
 # ## Numerical parameters and time-stepping parameters
 
-      n = 128            # 2D resolution: n² grid points
+      n = 128*4            # 2D resolution: n² grid points
 stepper = "FilteredRK4"  # timestepper
-     dt = 0.05           # timestep
- nsteps = 8000           # total number of timesteps
- save_substeps = 10      # number of timesteps after which output is saved
+     dt = 0.05/4           # timestep
+ nsteps = 8000*4          # total number of timesteps
+ save_substeps = 10*2      # number of timesteps after which output is saved
  
-nothing # hide
+nothing #hide
 
 
 # ## Physical parameters
@@ -48,7 +48,7 @@ nothing # hide
 L = 2π        # domain size
 β = 10.0      # planetary PV gradient
 μ = 0.01      # bottom drag
-nothing # hide
+nothing #hide
 
 
 # ## Forcing
@@ -73,12 +73,12 @@ forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2
 
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
 @. forcing_spectrum *= ε/ε0       # normalize forcing to inject energy at rate ε
-nothing # hide
+nothing #hide
 
 
 # We reset of the random number generator for reproducibility
 if dev==CPU(); Random.seed!(1234); else; CUDA.seed!(1234); end
-nothing # hide
+nothing #hide
 
 
 # Next we construct function `calcF!` that computes a forcing realization every timestep.
@@ -92,7 +92,7 @@ function calcF!(Fh, sol, t, clock, vars, params, grid)
 
   return nothing
 end
-nothing # hide
+nothing #hide
 
 
 # ## Problem setup
@@ -102,13 +102,13 @@ nothing # hide
 # stabilize the problem, despite that we use the default viscosity coefficient `ν=0`.
 prob = SingleLayerQG.Problem(dev; nx=n, Lx=L, β, μ, dt, stepper,
                              calcF=calcF!, stochastic=true)
-nothing # hide
+nothing #hide
 
 # Let's define some shortcuts.
 sol, clock, vars, params, grid = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 x,  y  = grid.x,  grid.y
 Lx, Ly = grid.Lx, grid.Ly
-nothing # hide
+nothing #hide
 
 
 # First let's see how a forcing realization looks like. Note that when plotting, we decorate 
@@ -143,7 +143,7 @@ SingleLayerQG.set_q!(prob, device_array(dev)(zeros(grid.nx, grid.ny)))
 E = Diagnostic(SingleLayerQG.energy, prob; nsteps, freq=save_substeps)
 Z = Diagnostic(SingleLayerQG.enstrophy, prob; nsteps, freq=save_substeps)
 diags = [E, Z] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
-nothing # hide
+nothing #hide
 
 
 # ## Output
@@ -153,12 +153,12 @@ filepath = "."
 plotpath = "./plots_forcedbetaturb"
 plotname = "snapshots"
 filename = joinpath(filepath, "singlelayerqg_forcedbeta.jld2")
-nothing # hide
+nothing #hide
 
 # Do some basic file management,
 if isfile(filename); rm(filename); end
 if !isdir(plotpath); mkdir(plotpath); end
-nothing # hide
+nothing #hide
 
 # and then create Output.
 get_sol(prob) = Array(prob.sol) # extracts the Fourier-transformed solution
@@ -176,7 +176,7 @@ function get_u(prob)
 end
 
 output = Output(prob, filename, (:qh, get_sol), (:u, get_u))
-nothing # hide
+nothing #hide
 
 # We first save the problem's grid and other parameters so we can use them later.
 saveproblem(output)
@@ -225,8 +225,8 @@ t = [file["snapshots/t/$i"] for i ∈ iterations]
 qh = [file["snapshots/qh/$i"] for i ∈ iterations]
 u  = [file["snapshots/u/$i"] for i ∈ iterations]
 
-E_t  = file["diagnostics/energy/t"]
-Z_t  = file["diagnostics/enstrophy/t"]
+E_t = file["diagnostics/energy/t"]
+Z_t = file["diagnostics/enstrophy/t"]
 E_data = file["diagnostics/energy/data"]
 Z_data = file["diagnostics/enstrophy/data"]
 
@@ -239,12 +239,12 @@ close(file)
 
 # We create a figure using Makie's [`Observable`](https://makie.juliaplots.org/stable/documentation/nodes/)s
 
-j = Observable(1)
+n = Observable(1)
 
-q = @lift irfft(qh[$j], nx)
-ψ = @lift irfft(- Array(grid.invKrsq) .* qh[$j], nx)
-q̄ = @lift real(ifft(qh[$j][1, :] / ny))
-ū = @lift vec(mean(u[$j], dims=1))
+qₙ = @lift irfft(qh[$j], nx)
+ψₙ = @lift irfft(- Array(grid.invKrsq) .* qh[$j], nx)
+q̄ₙ = @lift real(ifft(qh[$j][1, :] / ny))
+ūₙ = @lift vec(mean(u[$j], dims=1))
 
 title_q = @lift @sprintf("vorticity, μt = %.2f", μ * t[$j])
 
@@ -311,13 +311,13 @@ fig
 # We are now ready to animate all saved output.
 
 frames = 1:length(t)
-record(fig, "singlelayerqg_betaforced.mp4", frames, framerate = 18) do i
-  j[] = i
+record(fig, "singlelayerqg_betaforced.mp4", frames, framerate = 24) do i
+  n[] = i
 
   energy[] = push!(energy[], Point2f(μ * E_t[i], E_data[i]))
   enstrophy[] = push!(enstrophy[], Point2f(μ * Z_t[i], Z_data[i]))
 end
-nothing # hide
+nothing #hide
 
 # ![](singlelayerqg_betaforced.mp4)
 

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -32,11 +32,11 @@ nothing #hide
 
 # ## Numerical parameters and time-stepping parameters
 
-      n = 128*4            # 2D resolution: n² grid points
+      n = 128            # 2D resolution: n² grid points
 stepper = "FilteredRK4"  # timestepper
-     dt = 0.05/4           # timestep
- nsteps = 8000*4          # total number of timesteps
- save_substeps = 10*2      # number of timesteps after which output is saved
+     dt = 0.05           # timestep
+ nsteps = 8000          # total number of timesteps
+ save_substeps = 10      # number of timesteps after which output is saved
  
 nothing #hide
 
@@ -239,14 +239,14 @@ close(file)
 
 n = Observable(1)
 
-qₙ = @lift irfft(qh[$j], nx)
-ψₙ = @lift irfft(- Array(grid.invKrsq) .* qh[$j], nx)
-q̄ₙ = @lift real(ifft(qh[$j][1, :] / ny))
-ūₙ = @lift vec(mean(u[$j], dims=1))
+qₙ = @lift irfft(qh[$n], nx)
+ψₙ = @lift irfft(- Array(grid.invKrsq) .* qh[$n], nx)
+q̄ₙ = @lift real(ifft(qh[$n][1, :] / ny))
+ūₙ = @lift vec(mean(u[$n], dims=1))
 
-title_q = @lift @sprintf("vorticity, μt = %.2f", μ * t[$j])
+title_q = @lift @sprintf("vorticity, μt = %.2f", μ * t[$n])
 
-energy = Observable([Point2f(E_t[1], E_data[1])])
+energy    = Observable([Point2f(E_t[1], E_data[1])])
 enstrophy = Observable([Point2f(Z_t[1], Z_data[1])])
 
 fig = Figure(resolution=(1000, 600))
@@ -284,20 +284,20 @@ axZ = Axis(fig[2, 3],
            aspect = 1,
            limits = ((-0.1, 4.1), (0, 3.1)))
 
-heatmap!(axq, x, y, q;
+heatmap!(axq, x, y, qₙ;
          colormap = :balance, colorrange = (-8, 8))
 
 levels = collect(-0.32:0.04:0.32)
 
-contourf!(axψ, x, y, ψ;
+contourf!(axψ, x, y, ψₙ;
           levels, colormap = :viridis, colorrange = (-0.22, 0.22))
-contour!(axψ, x, y, ψ;
+contour!(axψ, x, y, ψₙ;
          levels, color = :black)
 
-lines!(axq̄, q̄, y; linewidth = 3)
+lines!(axq̄, q̄ₙ, y; linewidth = 3)
 lines!(axq̄, 0y, y; linewidth = 1, linestyle=:dash)
 
-lines!(axū, ū, y; linewidth = 3)
+lines!(axū, ūₙ, y; linewidth = 3)
 lines!(axū, 0y, y; linewidth = 1, linestyle=:dash)
 
 lines!(axE, energy; linewidth = 3)
@@ -309,10 +309,10 @@ fig
 # We are now ready to animate all saved output.
 
 frames = 1:length(t)
-record(fig, "singlelayerqg_betaforced.mp4", frames, framerate = 24) do i
+record(fig, "singlelayerqg_betaforced.mp4", frames, framerate = 16) do i
   n[] = i
 
-  energy[] = push!(energy[], Point2f(μ * E_t[i], E_data[i]))
+  energy[]    = push!(energy[],    Point2f(μ * E_t[i], E_data[i]))
   enstrophy[] = push!(enstrophy[], Point2f(μ * Z_t[i], Z_data[i]))
 end
 nothing #hide

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -1,7 +1,5 @@
 # # [Forced-dissipative barotropic QG beta-plane turbulence](@id singlelayerqg_betaforced_example)
 #
-#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/literated/singlelayerqg_betaforced.ipynb).
-#
 # A simulation of forced-dissipative barotropic quasi-geostrophic turbulence on 
 # a beta plane. The dynamics include linear drag and stochastic excitation.
 #

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -1,7 +1,5 @@
 # # [SingleLayerQG decaying 2D turbulence with and without finite Rossby radius of deformation](@id singlelayerqg_decaying_barotropic_equivalentbarotropic_example)
 #
-#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/literated/singlelayerqg_decaying_barotropic_equivalentbarotropic.ipynb).
-#
 # We use here the `SingleLayerQG` module to simulate decaying two-dimensional turbulence and
 # investigate how does a finite Rossby radius of deformation affects its evolution.
 #

--- a/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
+++ b/examples/singlelayerqg_decaying_barotropic_equivalentbarotropic.jl
@@ -27,7 +27,7 @@ using Random: seed!
 # ## Choosing a device: CPU or GPU
 
 dev = CPU()     # Device (CPU/GPU)
-nothing # hide
+nothing #hide
 
 
 # ## Numerical, domain, and simulation parameters
@@ -36,13 +36,13 @@ nothing # hide
 
 n, L  = 128, 2π             # grid resolution and domain length
 deformation_radius = 0.35   # the deformation radius
-nothing # hide
+nothing #hide
 
 ## Then we pick the time-stepper parameters
     dt = 1e-2  # timestep
 nsteps = 4000  # total number of steps
  nsubs = 20    # number of steps between each plot
-nothing # hide
+nothing #hide
 
 
 # ## Problem setup
@@ -59,7 +59,7 @@ stepper="FilteredRK4"
 
 prob_bqg = SingleLayerQG.Problem(dev; nx=n, Lx=L, dt, stepper, aliased_fraction=0)
 prob_eqbqg = SingleLayerQG.Problem(dev; nx=n, Lx=L, deformation_radius, dt, stepper, aliased_fraction=0)
-nothing # hide
+nothing #hide
 
 
 # ## Setting initial conditions
@@ -69,7 +69,7 @@ nothing # hide
 seed!(1234)
 k₀, E₀ = 6, 0.5
 ∇²ψ₀ = peakedisotropicspectrum(prob_bqg.grid, k₀, E₀, mask=prob_bqg.timestepper.filter)
-nothing # hide
+nothing #hide
 
 # `SingleLayerQG` allows us to set up the initial ``q`` for each problem via `set_q!()` function.
 # To initialize both `prob_bqg` and `prob_eqbqg` with the same flow, we first use function 
@@ -79,17 +79,17 @@ nothing # hide
 ∇²ψ₀h = rfft(∇²ψ₀)
 ψ₀h = @. 0 * ∇²ψ₀h
 SingleLayerQG.streamfunctionfrompv!(ψ₀h, ∇²ψ₀h, prob_bqg.params, prob_bqg.grid)
-nothing # hide
+nothing #hide
 
 # and then use the streamfunction to compute the corresponding ``q_0`` for each problem,
 q₀_bqg   = irfft(-prob_bqg.grid.Krsq .* ψ₀h, prob_bqg.grid.nx)
 q₀_eqbqg = irfft(-(prob_eqbqg.grid.Krsq .+ 1/prob_eqbqg.params.deformation_radius^2) .* ψ₀h, prob_bqg.grid.nx)
-nothing # hide
+nothing #hide
 
 # Now we can initialize our problems with the same flow.
 SingleLayerQG.set_q!(prob_bqg, q₀_bqg)
 SingleLayerQG.set_q!(prob_eqbqg, q₀_eqbqg)
-nothing # hide
+nothing #hide
 
 
 # Let's plot the initial vorticity field for each problem. Note that when plotting, we decorate 
@@ -164,6 +164,6 @@ record(fig, "singlelayerqg_barotropic_equivalentbarotropic.mp4", 0:Int(nsteps/ns
   ζ_bqg[] = relativevorticity(prob_bqg)
   ζ_eqbqg[] = relativevorticity(prob_eqbqg)
 end
-nothing # hide
+nothing #hide
 
 # ![](singlelayerqg_barotropic_equivalentbarotropic.mp4)

--- a/examples/singlelayerqg_decaying_topography.jl
+++ b/examples/singlelayerqg_decaying_topography.jl
@@ -1,7 +1,5 @@
 # # [Decaying barotropic QG turbulence over topography](@id singlelayerqg_decaying_topography)
 #
-#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/literated/singlelayerqg_decaying_topography.ipynb).
-# 
 # An example of decaying barotropic quasi-geostrophic turbulence over topography.
 #
 # ## Install dependencies

--- a/examples/singlelayerqg_decaying_topography.jl
+++ b/examples/singlelayerqg_decaying_topography.jl
@@ -122,15 +122,15 @@ title_ψ = Observable("initial streamfunction ψ")
 axψ = Axis(fig[1, 3]; title = title_ψ, axis_kwargs...)
 
 hm = heatmap!(axq, x, y, q;
-         colormap = :balance, colorrange = (-8, 8))
+              colormap = :balance, colorrange = (-8, 8))
 
 Colorbar(fig[1, 2], hm)
 
 levels = collect(range(-0.28, stop=0.28, length=11))
 
 hc = contourf!(axψ, x, y, ψ;
-          levels, colormap = :viridis, colorrange = (-0.28, 0.28),
-          extendlow = :auto, extendhigh = :auto)
+               levels, colormap = :viridis, colorrange = (-0.28, 0.28),
+               extendlow = :auto, extendhigh = :auto)
 contour!(axψ, x, y, ψ;
          levels, color = :black)
 

--- a/examples/singlelayerqg_decaying_topography.jl
+++ b/examples/singlelayerqg_decaying_topography.jl
@@ -24,7 +24,7 @@ using Statistics: mean
 # ## Choosing a device: CPU or GPU
 
 dev = CPU()     # Device (CPU/GPU)
-nothing # hide
+nothing #hide
 
 
 # ## Numerical parameters and time-stepping parameters
@@ -34,19 +34,19 @@ stepper = "FilteredRK4"  # timestepper
      dt = 0.05           # timestep
  nsteps = 2000           # total number of time-steps
  nsubs  = 10             # number of time-steps for intermediate logging/plotting (nsteps must be multiple of nsubs)
-nothing # hide
+nothing #hide
 
 
 # ## Physical parameters
 
 L = 2π        # domain size
-nothing # hide
+nothing #hide
 
 # Define the topographic potential vorticity, ``\eta = f_0 h(x, y)/H``. The topography here is 
 # an elliptical mount at ``(x, y) = (1, 1)``, and an elliptical depression at ``(x, y) = (-1, -1)``.
 σx, σy = 0.4, 0.8
 topographicPV(x, y) = 3exp(-(x - 1)^2 / 2σx^2 - (y - 1)^2 / 2σy^2) - 2exp(- (x + 1)^2 / 2σx^2 - (y + 1)^2 / 2σy^2)
-nothing # hide
+nothing #hide
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments.
@@ -58,13 +58,13 @@ nothing # hide
 # The topophic PV is prescribed via keyword argument `eta`.
 prob = SingleLayerQG.Problem(dev; nx=n, Lx=L, eta=topographicPV,
                              dt, stepper, aliased_fraction=0)
-nothing # hide
+nothing #hide
 
 # and define some shortcuts
 sol, clock, vars, params, grid = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 x,  y  = grid.x,  grid.y
 Lx, Ly = grid.Lx, grid.Ly
-nothing # hide
+nothing #hide
 
 # and let's plot the topographic PV. Note that when plotting, we decorate the variable to be 
 # plotted with `Array()` to make sure it is brought back on the CPU when the variable lives 
@@ -103,7 +103,7 @@ qih *= sqrt(E₀ / SingleLayerQG.energy(qih, vars, params, grid))  # normalize q
 qi = irfft(qih, grid.nx)
 
 SingleLayerQG.set_q!(prob, qi)
-nothing # hide
+nothing #hide
 
 # Let's plot the initial vorticity and streamfunction.
 
@@ -147,7 +147,7 @@ fig
 E = Diagnostic(SingleLayerQG.energy, prob; nsteps)
 Z = Diagnostic(SingleLayerQG.enstrophy, prob; nsteps)
 diags = [E, Z] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
-nothing # hide
+nothing #hide
 
 
 # ## Output
@@ -155,16 +155,16 @@ nothing # hide
 # We choose folder for outputing `.jld2` files.
 filepath = "."
 filename = joinpath(filepath, "decayingbetaturb.jld2")
-nothing # hide
+nothing #hide
 
 # Do some basic file management,
 if isfile(filename); rm(filename); end
-nothing # hide
+nothing #hide
 
 # and then create Output.
 get_sol(prob) = prob.sol # extracts the Fourier-transformed solution
 out = Output(prob, filename, (:sol, get_sol))
-nothing # hide
+nothing #hide
 
 
 # ## Visualizing the simulation
@@ -181,7 +181,7 @@ contour!(axq, x, y, η;
 title_q[] = "vorticity, t=" * @sprintf("%.2f", clock.t)
 title_ψ[] = "streamfunction ψ"
 
-nothing # hide
+nothing #hide
 
 
 # ## Time-stepping the `Problem` forward
@@ -209,6 +209,6 @@ record(fig, "singlelayerqg_decaying_topography.mp4", 0:round(Int, nsteps/nsubs),
   stepforward!(prob, diags, nsubs)
   SingleLayerQG.updatevars!(prob)
 end
-nothing # hide
+nothing #hide
 
 # ![](singlelayerqg_decaying_topography.mp4)

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -30,7 +30,7 @@ using Random: seed!
 # ## Choosing a device: CPU or GPU
 
 dev = CPU()     # Device (CPU/GPU)
-nothing # hide
+nothing #hide
 
 
 # ## Numerical parameters and time-stepping parameters
@@ -41,7 +41,7 @@ stepper = "FilteredETDRK4"          # timestepper
      tf = 60                        # length of time for simulation
  nsteps = Int(tf / dt)              # total number of time-steps
  nsubs  = round(Int, nsteps/100)    # number of time-steps for intermediate logging/plotting (nsteps must be multiple of nsubs)
-nothing # hide
+nothing #hide
 
 
 # ## Physical parameters
@@ -49,7 +49,7 @@ nothing # hide
  L = 2π        # domain size
  ν = 1e-19     # hyper-viscosity coefficient
 nν = 4         # hyper-viscosity order
-nothing # hide
+nothing #hide
 
 
 # ## Problem setup
@@ -59,13 +59,13 @@ nothing # hide
 # stabilize the problem, despite that we use the default viscosity coefficient `ν=0`.
 
 prob = SurfaceQG.Problem(dev; nx=n, Lx=L, dt, stepper, ν, nν)
-nothing # hide
+nothing #hide
 
 # Let's define some shortcuts.
 sol, clock, vars, params, grid = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 x,  y  = grid.x,  grid.y
 Lx, Ly = grid.Lx, grid.Ly
-#md nothing # hide
+#md nothing #hide
 
 
 # ## Setting initial conditions
@@ -75,7 +75,7 @@ X, Y = gridpoints(grid)
 b₀ = @. exp(-(X^2 + 4Y^2))
 
 SurfaceQG.set_b!(prob, b₀)
-nothing # hide
+nothing #hide
 
 # Let's plot the initial condition. Note that when plotting, we decorate the variable to be 
 # plotted with `Array()` to make sure it is brought back on the CPU when `vars` live on the GPU.
@@ -105,7 +105,7 @@ B  = Diagnostic(SurfaceQG.buoyancy_variance, prob; nsteps)
 KE = Diagnostic(SurfaceQG.kinetic_energy, prob; nsteps)
 Dᵇ = Diagnostic(SurfaceQG.buoyancy_dissipation, prob; nsteps)
 diags = [B, KE, Dᵇ] # A list of Diagnostics types passed to `stepforward!`. Diagnostics are updated every timestep.
-nothing # hidenothing # hide
+nothing #hidenothing #hide
 
 
 # ## Output
@@ -119,19 +119,19 @@ plotpath = "./"
 
 dataname = joinpath(datapath, base_filename)
 plotname = joinpath(plotpath, base_filename)
-nothing # hide
+nothing #hide
 
 # Do some basic file management,
 if !isdir(plotpath); mkdir(plotpath); end
 if !isdir(datapath); mkdir(datapath); end
-nothing # hide
+nothing #hide
 
 # and then create Output.
 get_sol(prob) = prob.sol # extracts the Fourier-transformed solution
 get_u(prob) = irfft(im * prob.grid.l .* sqrt.(prob.grid.invKrsq) .* prob.sol, prob.grid.nx)
 
 out = Output(prob, dataname, (:sol, get_sol), (:u, get_u))
-nothing # hide
+nothing #hide
 
 
 # ## Visualizing the simulation
@@ -199,7 +199,7 @@ record(fig, "sqg_ellipticalvortex.mp4", 0:round(Int, nsteps/nsubs), framerate = 
   stepforward!(prob, diags, nsubs)
   SurfaceQG.updatevars!(prob)
 end
-nothing # hide
+nothing #hide
 
 # ![](sqg_ellipticalvortex.mp4)
 

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -1,8 +1,5 @@
 # # [Decaying Surface QG turbulence](@id surfaceqg_decaying_example)
 #
-#md # This example can be run online via [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/literated/surfaceqg_decaying.ipynb).
-#md # Also, it can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/literated/surfaceqg_decaying.ipynb).
-#
 # A simulation of decaying surface quasi-geostrophic turbulence.
 # We reproduce here the initial value problem for an elliptical 
 # vortex as done by Held et al. 1995, _J. Fluid Mech_.

--- a/examples/surfaceqg_decaying.jl
+++ b/examples/surfaceqg_decaying.jl
@@ -215,17 +215,17 @@ axu = Axis(fig[1, 2]; title = "uₛ(x, y, t=" * @sprintf("%.2f", clock.t) * ")",
 axv = Axis(fig[1, 3]; title = "vₛ(x, y, t=" * @sprintf("%.2f", clock.t) * ")", axis_kwargs...)
 
 hb = heatmap!(axb, x, y, Array(vars.b);
-             colormap = :deep, colorrange = (0, 1))
+              colormap = :deep, colorrange = (0, 1))
 
 Colorbar(fig[2, 1], hb, vertical = false)
 
 hu = heatmap!(axu, x, y, Array(vars.u);
-             colormap = :balance, colorrange = (-maximum(abs.(vars.u)), maximum(abs.(vars.u))))
+              colormap = :balance, colorrange = (-maximum(abs.(vars.u)), maximum(abs.(vars.u))))
 
 Colorbar(fig[2, 2], hu, vertical = false)
 
 hv = heatmap!(axv, x, y, Array(vars.v);
-             colormap = :balance, colorrange = (-maximum(abs.(vars.v)), maximum(abs.(vars.v))))
+              colormap = :balance, colorrange = (-maximum(abs.(vars.v)), maximum(abs.(vars.v))))
 
 Colorbar(fig[2, 3], hv, vertical = false)
 

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -25,7 +25,7 @@ using GeophysicalFlows: peakedisotropicspectrum
 # ## Choosing a device: CPU or GPU
 
 dev = CPU()     # Device (CPU/GPU)
-nothing # hide
+nothing #hide
 
 
 # ## Numerical, domain, and simulation parameters
@@ -33,13 +33,13 @@ nothing # hide
 # First, we pick some numerical and physical parameters for our model.
 
 n, L  = 128, 2π             # grid resolution and domain length
-nothing # hide
+nothing #hide
 
 # Then we pick the time-stepper parameters
     dt = 1e-2  # timestep
 nsteps = 4000  # total number of steps
  nsubs = 20    # number of steps between each plot
-nothing # hide
+nothing #hide
 
 
 # ## Problem setup
@@ -49,13 +49,13 @@ nothing # hide
 # stabilize the problem, despite that we use the default viscosity coefficient `ν=0`.
 
 prob = TwoDNavierStokes.Problem(dev; nx=n, Lx=L, ny=n, Ly=L, dt, stepper="FilteredRK4")
-nothing # hide
+nothing #hide
 
 # Next we define some shortcuts for convenience.
 sol, clock, vars, grid = prob.sol, prob.clock, prob.vars, prob.grid
 x,  y  = grid.x,  grid.y
 Lx, Ly = grid.Lx, grid.Ly
-nothing # hide
+nothing #hide
 
 
 # ## Setting initial conditions
@@ -65,7 +65,7 @@ seed!(1234)
 k₀, E₀ = 6, 0.5
 ζ₀ = peakedisotropicspectrum(grid, k₀, E₀, mask=prob.timestepper.filter)
 TwoDNavierStokes.set_ζ!(prob, ζ₀)
-nothing # hide
+nothing #hide
 
 # Let's plot the initial vorticity field. Note that when plotting, we decorate the variable 
 # to be plotted with `Array()` to make sure it is brought back on the CPU when `vars` live on 
@@ -91,7 +91,7 @@ fig
 E = Diagnostic(TwoDNavierStokes.energy, prob; nsteps)
 Z = Diagnostic(TwoDNavierStokes.enstrophy, prob; nsteps)
 diags = [E, Z] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
-nothing # hide
+nothing #hide
 
 
 # ## Output
@@ -101,12 +101,12 @@ filepath = "."
 plotpath = "./plots_decayingTwoDNavierStokes"
 plotname = "snapshots"
 filename = joinpath(filepath, "decayingTwoDNavierStokes.jld2")
-nothing # hide
+nothing #hide
 
 # Do some basic file management
 if isfile(filename); rm(filename); end
 if !isdir(plotpath); mkdir(plotpath); end
-nothing # hide
+nothing #hide
 
 # And then create Output
 get_sol(prob) = prob.sol # extracts the Fourier-transformed solution
@@ -114,7 +114,7 @@ get_u(prob) = irfft(im * prob.grid.l .* prob.grid.invKrsq .* prob.sol, prob.grid
 
 out = Output(prob, filename, (:sol, get_sol), (:u, get_u))
 saveproblem(out)
-nothing # hide
+nothing #hide
 
 
 # ## Visualizing the simulation
@@ -176,7 +176,7 @@ record(fig, "twodturb.mp4", 0:Int(nsteps/nsubs), framerate = 18) do j
   stepforward!(prob, diags, nsubs)
   TwoDNavierStokes.updatevars!(prob)  
 end
-nothing # hide
+nothing #hide
 
 # ![](twodturb.mp4)
 
@@ -191,7 +191,7 @@ Eh = rfft(E)                         # Fourier transform of energy density
 
 ## compute radial specturm of `Eh`
 kr, Ehr = FourierFlows.radialspectrum(Eh, grid, refinement = 1)
-nothing # hide
+nothing #hide
 
 # and we plot it.
 lines(kr, vec(abs.(Ehr));

--- a/examples/twodnavierstokes_decaying.jl
+++ b/examples/twodnavierstokes_decaying.jl
@@ -1,7 +1,5 @@
 # # [2D decaying turbulence](@id twodnavierstokes_decaying_example)
 #
-#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/literated/twodnavierstokes_decaying.ipynb).
-#
 # A simulation of decaying two-dimensional turbulence.
 # 
 # ## Install dependencies

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -169,7 +169,7 @@ heatmap!(axζ, x, y, ζ;
 
 hE = lines!(ax2, energy; linewidth = 3)
 hZ = lines!(ax2, enstrophy; linewidth = 3, color = :red)
-Legend(fig[1, 3], [hE, hZ], ["energy E(t)" "enstrophy Z(t) / k_f²"])
+Legend(fig[1, 3], [hE, hZ], ["energy E(t)", "enstrophy Z(t) / k_f²"])
 
 fig
 

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -1,7 +1,5 @@
 # # [2D forced-dissipative turbulence](@id twodnavierstokes_stochasticforcing_example)
 #
-#md # This example can be viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/literated/twodnavierstokes_stochasticforcing.ipynb).
-#
 # A simulation of forced-dissipative two-dimensional turbulence. We solve the
 # two-dimensional vorticity equation with stochastic excitation and dissipation in
 # the form of linear drag and hyperviscosity. 

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -22,12 +22,12 @@ using GeophysicalFlows, CUDA, Random, Printf, CairoMakie
 
 parsevalsum = FourierFlows.parsevalsum
 record = CairoMakie.record                # disambiguate between CairoMakie.record and CUDA.record
-nothing # hide
+nothing #hide
 
 # ## Choosing a device: CPU or GPU
 
 dev = CPU()     # Device (CPU/GPU)
-nothing # hide
+nothing #hide
 
 
 # ## Numerical, domain, and simulation parameters
@@ -40,7 +40,7 @@ nothing # hide
     dt = 0.005               # timestep
 nsteps = 4000                # total number of steps
  nsubs = 20                  # number of steps between each plot
-nothing # hide
+nothing #hide
 
 
 # ## Forcing
@@ -65,12 +65,12 @@ forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2
 
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
 @. forcing_spectrum *= ε/ε0        # normalize forcing to inject energy at rate ε
-nothing # hide
+nothing #hide
 
 
 # We reset of the random number generator for reproducibility
 if dev==CPU(); Random.seed!(1234); else; CUDA.seed!(1234); end
-nothing # hide
+nothing #hide
 
 
 # Next we construct function `calcF!` that computes a forcing realization every timestep.
@@ -84,7 +84,7 @@ function calcF!(Fh, sol, t, clock, vars, params, grid)
   
   return nothing
 end
-nothing # hide
+nothing #hide
 
 
 # ## Problem setup
@@ -92,13 +92,13 @@ nothing # hide
 # `stepper` keyword defines the time-stepper to be used.
 prob = TwoDNavierStokes.Problem(dev; nx=n, Lx=L, ν, nν, μ, nμ, dt, stepper="ETDRK4",
                                 calcF=calcF!, stochastic=true)
-nothing # hide
+nothing #hide
 
 # Define some shortcuts for convenience.
 sol, clock, vars, params, grid = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 
 x, y = grid.x, grid.y
-nothing # hide
+nothing #hide
 
 
 # First let's see how a forcing realization looks like. Function `calcF!()` computes 
@@ -136,7 +136,7 @@ TwoDNavierStokes.set_ζ!(prob, device_array(dev)(zeros(grid.nx, grid.ny)))
 E  = Diagnostic(TwoDNavierStokes.energy,    prob; nsteps) # energy
 Z  = Diagnostic(TwoDNavierStokes.enstrophy, prob; nsteps) # enstrophy
 diags = [E, Z] # a list of Diagnostics passed to `stepforward!` will  be updated every timestep.
-nothing # hide
+nothing #hide
 
 
 # ## Visualizing the simulation
@@ -199,6 +199,6 @@ record(fig, "twodturb_forced.mp4", 0:round(Int, nsteps / nsubs), framerate = 18)
   stepforward!(prob, diags, nsubs)
   TwoDNavierStokes.updatevars!(prob)  
 end
-nothing # hide
+nothing #hide
 
 # ![](twodturb_forced.mp4)

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -228,14 +228,14 @@ hRᵋ = lines!(ax1E, t, Rᵋ[1:E.i-1]; linestyle = :solid)
 
 Legend(fig[2, 1],
        [hWᵋ, hε, hDᵋ, hRᵋ],
-       ["energy work, Wᵋ" "ensemble mean energy work, <Wᵋ>" "dissipation, Dᵋ" "drag, Rᵋ = - 2μE"])
+       ["energy work, Wᵋ", "ensemble mean energy work, <Wᵋ>", "dissipation, Dᵋ", "drag, Rᵋ = - 2μE"])
 
 hc = lines!(ax2E, t, dEdt_computed; linestyle = :solid)
 hn = lines!(ax2E, t, dEdt_numerical; linestyle = :dash)
 
 Legend(fig[4, 1],
        [hc, hn],
-       ["computed Wᵋ-Dᵋ" "numerical dE/dt"])
+       ["computed Wᵋ-Dᵋ", "numerical dE/dt"])
 
 hr = lines!(ax3E, t, residual_E)
 
@@ -250,14 +250,14 @@ hRᶻ = lines!(ax1Z, t, Rᶻ[1:Z.i-1]; linestyle = :solid)
 
 Legend(fig[2, 2],
        [hWᶻ, hεᶻ, hDᶻ, hRᶻ],
-       ["enstrophy work, Wᶻ" "ensemble mean enstophy work, <Wᶻ>" "dissipation, Dᶻ" "drag, Rᶻ = - 2μZ"])
+       ["enstrophy work, Wᶻ", "ensemble mean enstophy work, <Wᶻ>", "dissipation, Dᶻ", "drag, Rᶻ = - 2μZ"])
 
 hcᶻ = lines!(ax2Z, t, dZdt_computed; linestyle = :solid)
 hnᶻ = lines!(ax2Z, t, dZdt_numerical; linestyle = :dash)
 
 Legend(fig[4, 2],
        [hcᶻ, hnᶻ],
-       ["computed Wᶻ-Dᶻ" "numerical dZ/dt"])
+       ["computed Wᶻ-Dᶻ", "numerical dZ/dt"])
 
 hrᶻ = lines!(ax3Z, t, residual_Z)
 

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -1,7 +1,5 @@
 # # [2D forced-dissipative turbulence budgets](@id twodnavierstokes_stochasticforcing_budgets_example)
 #
-#md # This example can viewed as a Jupyter notebook via [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/literated/twodnavierstokes_stochasticforcing_budgets.ipynb).
-#
 # A simulation of forced-dissipative two-dimensional turbulence. We solve the
 # two-dimensional vorticity equation with stochastic excitation and dissipation in
 # the form of linear drag and hyperviscosity. As a demonstration, we compute how

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -24,12 +24,12 @@ using GeophysicalFlows, CUDA, Random, Printf, CairoMakie
 
 parsevalsum = FourierFlows.parsevalsum
 record = CairoMakie.record                # disambiguate between CairoMakie.record and CUDA.record
-nothing # hide
+nothing #hide
 
 # ## Choosing a device: CPU or GPU
 
 dev = CPU()     # Device (CPU/GPU)
-nothing # hide
+nothing #hide
 
 
 # ## Numerical, domain, and simulation parameters
@@ -42,7 +42,7 @@ nothing # hide
 dt, tf = 0.005, 0.2 / μ       # timestep and final time
     nt = round(Int, tf / dt)  # total timesteps
     ns = 4                    # how many intermediate times we want to plot
-nothing # hide
+nothing #hide
 
 
 # ## Forcing
@@ -67,12 +67,12 @@ forcing_spectrum = @. exp(-(K - forcing_wavenumber)^2 / (2 * forcing_bandwidth^2
 
 ε0 = parsevalsum(forcing_spectrum .* grid.invKrsq / 2, grid) / (grid.Lx * grid.Ly)
 @. forcing_spectrum *= ε/ε0        # normalize forcing to inject energy at rate ε
-nothing # hide
+nothing #hide
 
 
 # We reset of the random number generator for reproducibility
 if dev==CPU(); Random.seed!(1234); else; CUDA.seed!(1234); end
-nothing # hide
+nothing #hide
 
 
 # Next we construct function `calcF!` that computes a forcing realization every timestep.
@@ -86,7 +86,7 @@ function calcF!(Fh, sol, t, clock, vars, params, grid)
 
   return nothing
 end
-nothing # hide
+nothing #hide
 
 
 # ## Problem setup
@@ -94,14 +94,14 @@ nothing # hide
 # `stepper` keyword defines the time-stepper to be used.
 prob = TwoDNavierStokes.Problem(dev; nx=n, Lx=L, ν, nν, μ, nμ, dt, stepper="ETDRK4",
                                 calcF=calcF!, stochastic=true)
-nothing # hide
+nothing #hide
 
 # Define some shortcuts for convenience.
 sol, clock, vars, params, grid = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 
 x,  y  = grid.x,  grid.y
 Lx, Ly = grid.Lx, grid.Ly
-nothing # hide
+nothing #hide
 
 
 # First let's see how a forcing realization looks like. Function `calcF!()` computes 
@@ -145,7 +145,7 @@ Rᶻ = Diagnostic(TwoDNavierStokes.enstrophy_dissipation_hypoviscosity,  prob, n
 Dᶻ = Diagnostic(TwoDNavierStokes.enstrophy_dissipation_hyperviscosity, prob, nsteps=nt) # enstrophy dissipation by drag μ
 Wᶻ = Diagnostic(TwoDNavierStokes.enstrophy_work,                       prob, nsteps=nt) # enstrophy work input by forcing
 diags = [E, Dᵋ, Wᵋ, Rᵋ, Z, Dᶻ, Wᶻ, Rᶻ] # a list of Diagnostics passed to `stepforward!` will  be updated every timestep.
-nothing # hide
+nothing #hide
 
 # ## Time-stepping the `Problem` forward
 

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -936,12 +936,14 @@ function energies(vars, params, grid, sol)
   abs²∇𝐮h = vars.uh        # use vars.uh as scratch variable
   @. abs²∇𝐮h = grid.Krsq * abs2(vars.ψh)
   
+  LxLyH = grid.Lx * grid.Ly * sum(params.H)
+
   for j = 1:nlayers
-    views(KE, j) = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
+    @views KE[j] = 1 / (2 * LxLyH) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j]
   end
 
   for j = 1:nlayers-1
-    views(PE, j) = 1 / (2 * grid.Lx * grid.Ly * sum(params.H)) * params.f₀^2 / params.g′[j] * parsevalsum(abs2.(vars.ψh[:, :, j] .- vars.ψh[:, :, j+1]), grid)
+    @views PE[j] = 1 / (2 * LxLyH) * params.f₀^2 / params.g′[j] * parsevalsum(abs2.(vars.ψh[:, :, j] .- vars.ψh[:, :, j+1]), grid)
   end
 
   return KE, PE
@@ -957,10 +959,12 @@ function energies(vars, params::TwoLayerParams, grid, sol)
   abs²∇𝐮h = vars.uh        # use vars.uh as scratch variable
   @. abs²∇𝐮h = grid.Krsq * abs2(vars.ψh)
 
+  LxLyH = grid.Lx * grid.Ly * sum(params.H)
+
   ψ1h, ψ2h = view(vars.ψh, :, :, 1), view(vars.ψh, :, :, 2)
 
   for j = 1:nlayers
-    views(KE, j) = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
+    @views KE[j] = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
   end
 
   PE = 1 / (2 * grid.Lx * grid.Ly * sum(params.H)) * params.f₀^2 / params.g′ * parsevalsum(abs2.(ψ1h .- ψ2h), grid)

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -932,18 +932,19 @@ function energies(vars, params, grid, sol)
 
   @. vars.qh = sol
   streamfunctionfrompv!(vars.ψh, vars.qh, params, grid)
-  
+
   abs²∇𝐮h = vars.uh        # use vars.uh as scratch variable
   @. abs²∇𝐮h = grid.Krsq * abs2(vars.ψh)
   
+  H = reshape(params.H, (nlayers,))
   LxLyH = grid.Lx * grid.Ly * sum(params.H)
 
   for j = 1:nlayers
-    @views KE[j] = 1 / (2 * LxLyH) * parsevalsum(view(abs²∇𝐮h, :, :, j), grid) * params.H[j]
+    view(KE, j) .= 1 / (2 * LxLyH) * parsevalsum(view(abs²∇𝐮h, :, :, j), grid) .* view(params.H, j)
   end
 
   for j = 1:nlayers-1
-    @views PE[j] = 1 / (2 * LxLyH) * params.f₀^2 / params.g′[j] * parsevalsum(abs2.(view(vars.ψh, :, :, j) .- view(vars.ψh, :, :, j+1)), grid)
+    view(PE, j) .= 1 / (2 * LxLyH) * params.f₀^2 ./ view(params.g′, j) .* parsevalsum(abs2.(view(vars.ψh, :, :, j) .- view(vars.ψh, :, :, j+1)), grid)
   end
 
   return KE, PE
@@ -964,10 +965,10 @@ function energies(vars, params::TwoLayerParams, grid, sol)
   ψ1h, ψ2h = view(vars.ψh, :, :, 1), view(vars.ψh, :, :, 2)
 
   for j = 1:nlayers
-    @views KE[j] = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
+    view(KE, j) .= 1 / (2 * LxLyH) * parsevalsum(view(abs²∇𝐮h, :, :, j), grid) * params.H[j]
   end
 
-  PE = 1 / (2 * grid.Lx * grid.Ly * sum(params.H)) * params.f₀^2 / params.g′ * parsevalsum(abs2.(ψ1h .- ψ2h), grid)
+  PE = 1 / (2 * LxLyH) * params.f₀^2 / params.g′ * parsevalsum(abs2.(ψ1h .- ψ2h), grid)
   
   return KE, PE
 end

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -133,7 +133,7 @@ function Problem(nlayers::Int,                        # number of fluid layers
 end
 
 """
-    struct Params{T, Aphys3D, Aphys2D, Aphys1D, Atrans4D, Trfft} <: AbstractParams
+    struct Params{T, Aphys3D, Aphys2D, Atrans4D, Trfft} <: AbstractParams
 
 The parameters for the MultiLayerQG problem.
 

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -573,11 +573,11 @@ Obtain the Fourier transform of the PV from the streamfunction `ψh` for the spe
 case of a two fluid layer configuration. In this case we have,
 
 ```math
-q̂₁ = - k² ψ̂₁ + f₀² / (g′ H₁) * (ψ̂₂ - ψ̂₁) ,
+q̂₁ = - k² ψ̂₁ + f₀² / (g′ H₁) (ψ̂₂ - ψ̂₁) ,
 ```
 
 ```math
-q̂₂ = - k² ψ̂₂ + f₀² / (g′ H₂) * (ψ̂₁ - ψ̂₂) .
+q̂₂ = - k² ψ̂₂ + f₀² / (g′ H₂) (ψ̂₁ - ψ̂₂) .
 ```
 
 (Here, the PV-streamfunction relationship is hard-coded to avoid scalar operations

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -973,14 +973,14 @@ function energies(vars, params, grid, sol)
   abs²∇𝐮h = vars.uh        # use vars.uh as scratch variable
   @. abs²∇𝐮h = grid.Krsq * abs2(vars.ψh)
   
-  LxLyH = grid.Lx * grid.Ly * sum(params.H)
+  V = grid.Lx * grid.Ly * sum(params.H)
 
   for j = 1:nlayers
-    view(KE, j) .= 1 / (2 * LxLyH) * parsevalsum(view(abs²∇𝐮h, :, :, j), grid) * params.H[j]
+    view(KE, j) .= 1 / (2 * V) * parsevalsum(view(abs²∇𝐮h, :, :, j), grid) * params.H[j]
   end
 
   for j = 1:nlayers-1
-    view(PE, j) .= 1 / (2 * LxLyH) * params.f₀^2 ./ params.g′[j] .* parsevalsum(abs2.(view(vars.ψh, :, :, j) .- view(vars.ψh, :, :, j+1)), grid)
+    view(PE, j) .= 1 / (2 * V) * params.f₀^2 ./ params.g′[j] .* parsevalsum(abs2.(view(vars.ψh, :, :, j) .- view(vars.ψh, :, :, j+1)), grid)
   end
 
   return KE, PE
@@ -996,15 +996,15 @@ function energies(vars, params::TwoLayerParams, grid, sol)
   abs²∇𝐮h = vars.uh        # use vars.uh as scratch variable
   @. abs²∇𝐮h = grid.Krsq * abs2(vars.ψh)
 
-  LxLyH = grid.Lx * grid.Ly * sum(params.H)
+  V = grid.Lx * grid.Ly * sum(params.H)
 
   ψ1h, ψ2h = view(vars.ψh, :, :, 1), view(vars.ψh, :, :, 2)
 
   for j = 1:nlayers
-    view(KE, j) .= 1 / (2 * LxLyH) * parsevalsum(view(abs²∇𝐮h, :, :, j), grid) * params.H[j]
+    view(KE, j) .= 1 / (2 * V) * parsevalsum(view(abs²∇𝐮h, :, :, j), grid) * params.H[j]
   end
 
-  PE = 1 / (2 * LxLyH) * params.f₀^2 / params.g′ * parsevalsum(abs2.(ψ1h .- ψ2h), grid)
+  PE = 1 / (2 * V) * params.f₀^2 / params.g′ * parsevalsum(abs2.(ψ1h .- ψ2h), grid)
   
   return KE, PE
 end

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -930,11 +930,11 @@ function energies(vars, params, grid, sol)
   @. abs²∇𝐮h = grid.Krsq * abs2(vars.ψh)
   
   for j = 1:nlayers
-    CUDA.@allowscalar KE[j] = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
+    @views KE[j] = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
   end
 
   for j = 1:nlayers-1
-    CUDA.@allowscalar PE[j] = 1 / (2 * grid.Lx * grid.Ly) * params.f₀^2 / params.g′[j] * parsevalsum(abs2.(vars.ψh[:, :, j+1] .- vars.ψh[:, :, j]), grid)
+    @views PE[j] = 1 / (2 * grid.Lx * grid.Ly) * params.f₀^2 / params.g′[j] * parsevalsum(abs2.(vars.ψh[:, :, j+1] .- vars.ψh[:, :, j]), grid)
   end
 
   return KE, PE
@@ -953,7 +953,7 @@ function energies(vars, params::TwoLayerParams, grid, sol)
   ψ1h, ψ2h = view(vars.ψh, :, :, 1), view(vars.ψh, :, :, 2)
 
   for j = 1:nlayers
-    CUDA.@allowscalar KE[j] = @views 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
+    @views KE[j] = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
   end
 
   PE = @views 1 / (2 * grid.Lx * grid.Ly) * params.f₀^2 / params.g′ * parsevalsum(abs2.(ψ2h .- ψ1h), grid)
@@ -1011,8 +1011,8 @@ function fluxes(vars, params, grid, sol)
   lateralfluxes *= grid.dx * grid.dy / (grid.Lx * grid.Ly * sum(params.H))
 
   for j = 1:nlayers-1
-    CUDA.@allowscalar verticalfluxes[j] = sum(@views @. params.f₀^2 / params.g′[j] * (params.U[: ,:, j] - params.U[:, :, j+1]) * vars.v[:, :, j+1] * vars.ψ[:, :, j]; dims=(1, 2))[1]
-    CUDA.@allowscalar verticalfluxes[j] *= grid.dx * grid.dy / (grid.Lx * grid.Ly * sum(params.H))
+    @views verticalfluxes[j] = sum(@views @. params.f₀^2 / params.g′[j] * (params.U[: ,:, j] - params.U[:, :, j+1]) * vars.v[:, :, j+1] * vars.ψ[:, :, j]; dims=(1, 2))[1]
+    @views verticalfluxes[j] *= grid.dx * grid.dy / (grid.Lx * grid.Ly * sum(params.H))
   end
 
   return lateralfluxes, verticalfluxes

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -939,11 +939,11 @@ function energies(vars, params, grid, sol)
   LxLyH = grid.Lx * grid.Ly * sum(params.H)
 
   for j = 1:nlayers
-    @views KE[j] = 1 / (2 * LxLyH) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j]
+    @views KE[j] = 1 / (2 * LxLyH) * parsevalsum(view(abs²∇𝐮h, :, :, j), grid) * params.H[j]
   end
 
   for j = 1:nlayers-1
-    @views PE[j] = 1 / (2 * LxLyH) * params.f₀^2 / params.g′[j] * parsevalsum(abs2.(vars.ψh[:, :, j] .- vars.ψh[:, :, j+1]), grid)
+    @views PE[j] = 1 / (2 * LxLyH) * params.f₀^2 / params.g′[j] * parsevalsum(abs2.(view(vars.ψh, :, :, j) .- view(vars.ψh, :, :, j+1)), grid)
   end
 
   return KE, PE

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -937,11 +937,11 @@ function energies(vars, params, grid, sol)
   @. abs²∇𝐮h = grid.Krsq * abs2(vars.ψh)
   
   for j = 1:nlayers
-    @views KE[j] = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
+    views(KE, j) = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
   end
 
   for j = 1:nlayers-1
-    @views PE[j] = 1 / (2 * grid.Lx * grid.Ly * sum(params.H)) * params.f₀^2 / params.g′[j] * parsevalsum(abs2.(vars.ψh[:, :, j] .- vars.ψh[:, :, j+1]), grid)
+    views(PE, j) = 1 / (2 * grid.Lx * grid.Ly * sum(params.H)) * params.f₀^2 / params.g′[j] * parsevalsum(abs2.(vars.ψh[:, :, j] .- vars.ψh[:, :, j+1]), grid)
   end
 
   return KE, PE
@@ -960,10 +960,10 @@ function energies(vars, params::TwoLayerParams, grid, sol)
   ψ1h, ψ2h = view(vars.ψh, :, :, 1), view(vars.ψh, :, :, 2)
 
   for j = 1:nlayers
-    @views KE[j] = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
+    views(KE, j) = 1 / (2 * grid.Lx * grid.Ly) * parsevalsum(abs²∇𝐮h[:, :, j], grid) * params.H[j] / sum(params.H)
   end
 
-  PE = @views 1 / (2 * grid.Lx * grid.Ly * sum(params.H)) * params.f₀^2 / params.g′ * parsevalsum(abs2.(ψ1h .- ψ2h), grid)
+  PE = 1 / (2 * grid.Lx * grid.Ly * sum(params.H)) * params.f₀^2 / params.g′ * parsevalsum(abs2.(ψ1h .- ψ2h), grid)
   
   return KE, PE
 end

--- a/test/test_multilayerqg.jl
+++ b/test/test_multilayerqg.jl
@@ -143,6 +143,8 @@ function test_pvtofromstreamfunction_3layer(dev::Device=CPU())
   MultiLayerQG.streamfunctionfrompv!(vs.ψh, vs.qh, pr, gr)
   MultiLayerQG.invtransform!(vs.ψ, vs.ψh, pr)
 
+  MultiLayerQG.set_q!(prob, vs.q)
+
   KE, PE = MultiLayerQG.energies(prob)
 
   return isapprox(q1, vs.q[:, :, 1], rtol=rtol_multilayerqg) &&
@@ -361,7 +363,7 @@ function test_mqg_energies(dev::Device=CPU();
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   ψ = zeros(dev, eltype(gr), (gr.nx, gr.ny, nlayers))
-  
+
   CUDA.@allowscalar @views @. ψ[:, :, 1] =       cos(2k₀ * x) * cos(2l₀ * y)
   CUDA.@allowscalar @views @. ψ[:, :, 2] = 1/2 * cos(2k₀ * x) * cos(2l₀ * y)
 

--- a/test/test_multilayerqg.jl
+++ b/test/test_multilayerqg.jl
@@ -143,12 +143,14 @@ function test_pvtofromstreamfunction_3layer(dev::Device=CPU())
   MultiLayerQG.streamfunctionfrompv!(vs.ψh, vs.qh, pr, gr)
   MultiLayerQG.invtransform!(vs.ψ, vs.ψh, pr)
 
+  KE, PE = MultiLayerQG.energies(prob)
+
   return isapprox(q1, vs.q[:, :, 1], rtol=rtol_multilayerqg) &&
          isapprox(q2, vs.q[:, :, 2], rtol=rtol_multilayerqg) &&
          isapprox(q3, vs.q[:, :, 3], rtol=rtol_multilayerqg) &&
          isapprox(ψ1, vs.ψ[:, :, 1], rtol=rtol_multilayerqg) &&
          isapprox(ψ2, vs.ψ[:, :, 2], rtol=rtol_multilayerqg) &&
-         isapprox(ψ3, vs.ψ[:, :, 3], rtol=rtol_multilayerqg)
+         isapprox(ψ3, vs.ψ[:, :, 3], rtol=rtol_multilayerqg) &&
 end
 
 
@@ -197,8 +199,8 @@ function test_mqg_nonlinearadvection(dt, stepper, dev::Device=CPU();
   μ, ν, nν = 0.1, 0.05, 1
 
   η0, σx, σy = 1.0, Lx/25, Ly/20
-   η = @. η0*exp( -(x+Lx/8)^2/(2σx^2) - (y-Ly/8)^2/(2σy^2) )
-  ηx = @. -(x + Lx/8)/(σx^2) * η
+   η = @. η0 * exp( - (x + Lx/8)^2/2σx^2 - (y - Ly/8)^2/2σy^2)
+  ηx = @. -(x + Lx/8)/σx^2 * η
 
   ψ1, ψ2, q1, q2, ψ1x, ψ2x, q1x, q2x, Δψ2, Δq1, Δq2 = constructtestfields_2layer(gr)
 

--- a/test/test_multilayerqg.jl
+++ b/test/test_multilayerqg.jl
@@ -151,6 +151,8 @@ function test_pvtofromstreamfunction_3layer(dev::Device=CPU())
          isapprox(ψ1, vs.ψ[:, :, 1], rtol=rtol_multilayerqg) &&
          isapprox(ψ2, vs.ψ[:, :, 2], rtol=rtol_multilayerqg) &&
          isapprox(ψ3, vs.ψ[:, :, 3], rtol=rtol_multilayerqg) &&
+         KE isa Vector{Float64} && length(KE) == nlayers &&
+         PE isa Vector{Float64} && length(PE) == nlayers-1
 end
 
 

--- a/test/test_surfaceqg.jl
+++ b/test/test_surfaceqg.jl
@@ -189,7 +189,7 @@ function test_sqg_stochasticforcing_buoyancy_variance_budget(dev::Device=CPU(); 
     eta = device_array(dev)(exp.(2π * im * rand(Float64, size(sol))) / sqrt(clock.dt))
     CUDA.@allowscalar eta[1, 1] = 0.0
     @. Fh = eta * sqrt(forcing_spectrum)
-    nothing
+    return nothing
   end
 
   prob = SurfaceQG.Problem(dev; nx=n, Lx=L, ν=ν, nν=nν, dt=dt, stepper="RK4",

--- a/test/test_twodnavierstokes.jl
+++ b/test/test_twodnavierstokes.jl
@@ -100,8 +100,7 @@ function test_twodnavierstokes_stochasticforcing_enstrophybudget(dev::Device=CPU
     eta = device_array(dev)(exp.(2π * im * rand(Float64, size(sol))) / sqrt(cl.dt))
     CUDA.@allowscalar eta[1, 1] = 0.0
     @. Fh = eta * sqrt(forcing_spectrum)
-    
-    nothing
+    return nothing
   end
 
   prob = TwoDNavierStokes.Problem(dev; nx=n, Lx=L, ν=ν, nν=nν, μ=μ, nμ=nμ, dt=dt,


### PR DESCRIPTION
This is an attempt to resolve #273.

I benchmarked it. It's not any faster than v0.14.2. But it's cleaner.

Seems like scalar operations mentioned in #273 were not causing any bottleneck after all...

Bench script:

```Julia
using GeophysicalFlows, Printf
using Random: seed!

dev = GPU()     # Device (CPU/GPU)

n = 512                  # 2D resolution = n²
stepper = "FilteredRK4"  # timestepper
     dt = 0.5e-3         # timestep
 nsteps = 20000          # total number of time-steps
 nsubs  = 200            # number of time-steps for plotting (nsteps must be multiple of nsubs)

 L = 2π                  # domain size
μ = 5e-2                 # bottom drag
β = 5                    # the y-gradient of planetary PV
 
nlayers = 2              # number of layers
f₀, g = 1, 1             # Coriolis parameter and gravitational constant
H = [0.2, 0.8]           # the rest depths of each layer
ρ = [4.0, 5.0]           # the density of each layer
 
U = zeros(nlayers)       # the imposed mean zonal flow in each layer
U[1] = 1.0
U[2] = 0.0

prob = MultiLayerQG.Problem(nlayers, dev; nx=n, Lx=L, f₀, g, H, ρ, U, μ, β,
                            dt, stepper, aliased_fraction=0)

sol, clock, params, vars, grid = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
x, y = grid.x, grid.y

seed!(1234) # reset of the random number generator for reproducibility
q₀  = 1e-2 * ArrayType(dev)(randn((grid.nx, grid.ny, nlayers)))
q₀h = prob.timestepper.filter .* rfft(q₀, (1, 2)) # apply rfft  only in dims=1, 2
q₀  = irfft(q₀h, grid.nx, (1, 2))                 # apply irfft only in dims=1, 2

MultiLayerQG.set_q!(prob, q₀)

# Create Diagnostics -- `energies` function is imported at the top.
E = Diagnostic(MultiLayerQG.energies, prob; nsteps)
diags = [E] # A list of Diagnostics types passed to "stepforward!" will  be updated every timestep.
nothing # hide

stepforward!(prob, diags, nsubs)

startwalltime = time()

for j in 0:round(Int, nsteps / nsubs)
  if j % (1000 / nsubs) == 0
    cfl = clock.dt * maximum([maximum(vars.u) / grid.dx, maximum(vars.v) / grid.dy])
    
    log = @sprintf("step: %04d, t: %.1f, cfl: %.2f, KE₁: %.3e, KE₂: %.3e, PE: %.3e, walltime: %.2f min",
                   clock.step, clock.t, cfl, E.data[E.i][1][1], E.data[E.i][1][2], E.data[E.i][2][1], (time()-startwalltime)/60)

    println(log)
  end
  
  stepforward!(prob, diags, nsubs)
  MultiLayerQG.updatevars!(prob)
end
```

### Using this PR

```julia
step: 0200, t: 0.1, cfl: 0.00, KE₁: 1.132e-09, KE₂: 5.210e-09, PE: 2.476e-10, walltime: 0.00 min
step: 1200, t: 0.6, cfl: 0.00, KE₁: 1.551e-09, KE₂: 4.983e-09, PE: 1.317e-09, walltime: 0.07 min
step: 2200, t: 1.1, cfl: 0.00, KE₁: 2.142e-09, KE₂: 4.868e-09, PE: 2.515e-09, walltime: 0.14 min
step: 3200, t: 1.6, cfl: 0.00, KE₁: 2.718e-09, KE₂: 4.855e-09, PE: 3.338e-09, walltime: 0.21 min
step: 4200, t: 2.1, cfl: 0.00, KE₁: 3.221e-09, KE₂: 4.975e-09, PE: 3.492e-09, walltime: 0.29 min
step: 5200, t: 2.6, cfl: 0.00, KE₁: 3.872e-09, KE₂: 5.214e-09, PE: 3.589e-09, walltime: 0.36 min
step: 6200, t: 3.1, cfl: 0.00, KE₁: 5.084e-09, KE₂: 5.449e-09, PE: 5.163e-09, walltime: 0.43 min
step: 7200, t: 3.6, cfl: 0.00, KE₁: 6.869e-09, KE₂: 5.836e-09, PE: 7.685e-09, walltime: 0.50 min
step: 8200, t: 4.1, cfl: 0.00, KE₁: 9.229e-09, KE₂: 6.496e-09, PE: 1.071e-08, walltime: 0.57 min
step: 9200, t: 4.6, cfl: 0.00, KE₁: 1.229e-08, KE₂: 7.577e-09, PE: 1.397e-08, walltime: 0.64 min
step: 10200, t: 5.1, cfl: 0.00, KE₁: 1.630e-08, KE₂: 9.216e-09, PE: 1.759e-08, walltime: 0.72 min
step: 11200, t: 5.6, cfl: 0.00, KE₁: 2.200e-08, KE₂: 1.142e-08, PE: 2.344e-08, walltime: 0.78 min
step: 12200, t: 6.1, cfl: 0.00, KE₁: 3.007e-08, KE₂: 1.443e-08, PE: 3.233e-08, walltime: 0.85 min
step: 13200, t: 6.6, cfl: 0.00, KE₁: 4.135e-08, KE₂: 1.871e-08, PE: 4.477e-08, walltime: 0.92 min
step: 14200, t: 7.1, cfl: 0.00, KE₁: 5.703e-08, KE₂: 2.477e-08, PE: 6.181e-08, walltime: 0.99 min
step: 15200, t: 7.6, cfl: 0.00, KE₁: 7.877e-08, KE₂: 3.345e-08, PE: 8.464e-08, walltime: 1.06 min
step: 16200, t: 8.1, cfl: 0.00, KE₁: 1.093e-07, KE₂: 4.566e-08, PE: 1.168e-07, walltime: 1.13 min
step: 17200, t: 8.6, cfl: 0.00, KE₁: 1.524e-07, KE₂: 6.279e-08, PE: 1.628e-07, walltime: 1.21 min
step: 18200, t: 9.1, cfl: 0.00, KE₁: 2.130e-07, KE₂: 8.692e-08, PE: 2.275e-07, walltime: 1.28 min
step: 19200, t: 9.6, cfl: 0.00, KE₁: 2.983e-07, KE₂: 1.209e-07, PE: 3.185e-07, walltime: 1.35 min
step: 20200, t: 10.1, cfl: 0.00, KE₁: 4.182e-07, KE₂: 1.691e-07, PE: 4.456e-07, walltime: 1.42 min
```

### With GeophysicalFlows v0.14.2

```Julia
step: 0200, t: 0.1, cfl: 0.00, KE₁: 1.132e-09, KE₂: 5.210e-09, PE: 2.476e-10, walltime: 0.00 min
step: 1200, t: 0.6, cfl: 0.00, KE₁: 1.551e-09, KE₂: 4.983e-09, PE: 1.317e-09, walltime: 0.07 min
step: 2200, t: 1.1, cfl: 0.00, KE₁: 2.142e-09, KE₂: 4.868e-09, PE: 2.515e-09, walltime: 0.14 min
step: 3200, t: 1.6, cfl: 0.00, KE₁: 2.718e-09, KE₂: 4.855e-09, PE: 3.338e-09, walltime: 0.20 min
step: 4200, t: 2.1, cfl: 0.00, KE₁: 3.221e-09, KE₂: 4.975e-09, PE: 3.492e-09, walltime: 0.27 min
step: 5200, t: 2.6, cfl: 0.00, KE₁: 3.872e-09, KE₂: 5.214e-09, PE: 3.589e-09, walltime: 0.34 min
step: 6200, t: 3.1, cfl: 0.00, KE₁: 5.084e-09, KE₂: 5.449e-09, PE: 5.163e-09, walltime: 0.41 min
step: 7200, t: 3.6, cfl: 0.00, KE₁: 6.869e-09, KE₂: 5.836e-09, PE: 7.685e-09, walltime: 0.47 min
step: 8200, t: 4.1, cfl: 0.00, KE₁: 9.229e-09, KE₂: 6.496e-09, PE: 1.071e-08, walltime: 0.54 min
step: 9200, t: 4.6, cfl: 0.00, KE₁: 1.229e-08, KE₂: 7.577e-09, PE: 1.397e-08, walltime: 0.59 min
step: 10200, t: 5.1, cfl: 0.00, KE₁: 1.630e-08, KE₂: 9.216e-09, PE: 1.759e-08, walltime: 0.65 min
step: 11200, t: 5.6, cfl: 0.00, KE₁: 2.200e-08, KE₂: 1.142e-08, PE: 2.344e-08, walltime: 0.71 min
step: 12200, t: 6.1, cfl: 0.00, KE₁: 3.007e-08, KE₂: 1.443e-08, PE: 3.233e-08, walltime: 0.79 min
step: 13200, t: 6.6, cfl: 0.00, KE₁: 4.135e-08, KE₂: 1.871e-08, PE: 4.477e-08, walltime: 0.86 min
step: 14200, t: 7.1, cfl: 0.00, KE₁: 5.703e-08, KE₂: 2.477e-08, PE: 6.181e-08, walltime: 0.93 min
step: 15200, t: 7.6, cfl: 0.00, KE₁: 7.877e-08, KE₂: 3.345e-08, PE: 8.464e-08, walltime: 1.00 min
step: 16200, t: 8.1, cfl: 0.00, KE₁: 1.093e-07, KE₂: 4.566e-08, PE: 1.168e-07, walltime: 1.08 min
step: 17200, t: 8.6, cfl: 0.00, KE₁: 1.524e-07, KE₂: 6.279e-08, PE: 1.628e-07, walltime: 1.14 min
step: 18200, t: 9.1, cfl: 0.00, KE₁: 2.130e-07, KE₂: 8.692e-08, PE: 2.275e-07, walltime: 1.20 min
step: 19200, t: 9.6, cfl: 0.00, KE₁: 2.983e-07, KE₂: 1.209e-07, PE: 3.185e-07, walltime: 1.26 min
step: 20200, t: 10.1, cfl: 0.00, KE₁: 4.182e-07, KE₂: 1.691e-07, PE: 4.456e-07, walltime: 1.32 min
```