### PR TITLE
Docs delete `.jld2` files after build

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,8 @@ using
   Documenter,
   Literate,
   CairoMakie,   # to not capture precompilation output
-  GeophysicalFlows
+  GeophysicalFlows,
+  Glob
 
 #####
 ##### Generate literated examples
@@ -104,4 +105,10 @@ withenv("GITHUB_REPOSITORY" => "FourierFlows/GeophysicalFlowsDocumentation") do
             push_preview = false,
                devbranch = "main"
             )
+end
+
+@info "Cleaning up temporary .jld2 and .nc files created by doctests..."
+
+for file in vcat(glob("docs/*.jld2"), glob("docs/*.nc"))
+    rm(file)
 end


### PR DESCRIPTION
The docs build have large files that need to be deleted before deploying. This PR deletes any `.jld2` files produced by the docs before deploying.

https://github.com/FourierFlows/GeophysicalFlows.jl/runs/8092464776?check_suite_focus=true#step:6:2660