### PR TITLE
Option to specify topographic PV large-scale gradients in `MultiLayerQG`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "GeophysicalFlows"
 uuid = "44ee3b1c-bc02-53fa-8355-8e347616e15e"
 license = "MIT"
 authors = ["Navid C. Constantinou <navidcy@gmail.com>", "Gregory L. Wagner <wagner.greg@gmail.com>", "and co-contributors"]
-version = "0.15.0"
+version = "0.15.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -72,9 +72,9 @@ Keyword arguments
   - `U`: The imposed constant zonal flow ``U(y)`` in each fluid layer.
   - `H`: Rest height of each fluid layer.
   - `ρ`: Density of each fluid layer.
-  - `eta`: Periodic component of the topographic potential vorticity.
-  - `etax_nonperiodic`: ``x``-gradient of the non-periodic component of the topographic potential vorticity.
-  - `etay_nonperiodic`: ``y``-gradient of the non-periodic component of the topographic potential vorticity.
+  - `eta`: Periodic component of the topographic potential vorticity. Default: `nothing`.
+  - `etax_nonperiodic`: ``x``-gradient of the non-periodic component of the topographic potential vorticity. Default: `nothing`.
+  - `etay_nonperiodic`: ``y``-gradient of the non-periodic component of the topographic potential vorticity. Default: `nothing`.
   - `μ`: Linear bottom drag coefficient.
   - `ν`: Small-scale (hyper)-viscosity coefficient.
   - `nν`: (Hyper)-viscosity order, `nν```≥ 1``.
@@ -85,6 +85,12 @@ Keyword arguments
   - `linear`: `true` or `false` (default); boolean denoting whether the linearized equations of motions are used.
   - `aliased_fraction`: the fraction of high-wavenumbers that are zero-ed out by `dealias!()`.
   - `T`: `Float32` or `Float64`; floating point type used for `problem` data.
+
+!!! note "Prescribing topographic potential vorticity"
+    Only the topographic potential vorticity gradients come into play into time-stepping forward the `MultiLayerQG`
+    system. The derivatives of the `eta` compoent are computed spectrally and, therefore, `eta` is expected to
+    be periodic. Any non-periodic topographic potential vorticity gradients can be prescribed via the `etax_nonperiodic`
+    and `etax_nonperiodic` keyword arguments.
 """
 function Problem(nlayers::Int,                        # number of fluid layers
                      dev = CPU();

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -314,7 +314,7 @@ function convert_U_to_U3D(dev, nlayers, grid, U::Number)
   return A(U_3D)
 end
 
-function Params(nlayers, g, f₀, β, ρ, H, U, eta, etax_nonperiodic, etay_nonperiodic, μ, ν, nν, grid; calcFq=nothingfunction, effort=FFTW.MEASURE) where TU
+function Params(nlayers, g, f₀, β, ρ, H, U, eta, etax_nonperiodic, etay_nonperiodic, μ, ν, nν, grid; calcFq=nothingfunction, effort=FFTW.MEASURE)
   dev = grid.device
   T = eltype(grid)
   A = device_array(dev)

--- a/src/multilayerqg.jl
+++ b/src/multilayerqg.jl
@@ -73,8 +73,8 @@ Keyword arguments
   - `H`: Rest height of each fluid layer.
   - `ρ`: Density of each fluid layer.
   - `eta`: Periodic component of the topographic potential vorticity.
-  - `etax_nonperiodic`: x-gradient of the non-periodic component of the topographic potential vorticity.
-  - `etay_nonperiodic`: y-gradient of the non-periodic component of the topographic potential vorticity.
+  - `etax_nonperiodic`: ``x``-gradient of the non-periodic component of the topographic potential vorticity.
+  - `etay_nonperiodic`: ``y``-gradient of the non-periodic component of the topographic potential vorticity.
   - `μ`: Linear bottom drag coefficient.
   - `ν`: Small-scale (hyper)-viscosity coefficient.
   - `nν`: (Hyper)-viscosity order, `nν```≥ 1``.
@@ -101,8 +101,8 @@ function Problem(nlayers::Int,                        # number of fluid layers
                        H = 1/nlayers * ones(nlayers), # rest fluid height of each layer
                        ρ = Array{Float64}(1:nlayers), # density of each layer
                      eta = nothing,                   # periodic component of the topographic PV
-        etax_nonperiodic = nothing,                   # x-gradient of the non-periodic component of the topographic PV
-        etay_nonperiodic = nothing,                   # y-gradient of the non-periodic component of the topographic PV
+        etax_nonperiodic = nothing,                   # ``x``-gradient of the non-periodic component of the topographic PV
+        etay_nonperiodic = nothing,                   # ``y``-gradient of the non-periodic component of the topographic PV
               # Bottom Drag and/or (hyper)-viscosity
                        μ = 0,
                        ν = 0,
@@ -214,7 +214,7 @@ struct SingleLayerParams{T, Aphys3D, Aphys2D, Trfft} <: AbstractParams
          β :: T
     "array with imposed constant zonal flow ``U(y)``"
          U :: Aphys3D
-     "array containing periodic component of the topographic PV"
+     "array containing the periodic component of the topographic PV"
        eta :: Aphys2D
      "array containing ``x``-gradient of non-periodic component of the topographic PV"
        etax_nonperiodic :: Aphys2D

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,11 +18,11 @@ using GeophysicalFlows: lambdipole, peakedisotropicspectrum
 # the devices on which tests will run
 devices = CUDA.functional() ? (CPU(), GPU()) : (CPU(),)
 
-const rtol_lambdipole = 1e-2 # tolerance for lamb dipole tests
+const rtol_lambdipole = 1e-2        # tolerance for lamb dipole tests
 const rtol_twodnavierstokes = 1e-13 # tolerance for twodnavierstokes forcing tests
-const rtol_singlelayerqg = 1e-13 # tolerance for singlelayerqg forcing tests
-const rtol_multilayerqg = 1e-13 # tolerance for multilayerqg forcing tests
-const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
+const rtol_singlelayerqg = 1e-13    # tolerance for singlelayerqg forcing tests
+const rtol_multilayerqg = 1e-13     # tolerance for multilayerqg forcing tests
+const rtol_surfaceqg = 1e-13        # tolerance for surfaceqg forcing tests
 
 # Run tests
 testtime = @elapsed begin
@@ -128,7 +128,7 @@ for dev in devices
     @test test_mqg_fluxes(dev)
     @test test_mqg_fluxessinglelayer(dev)
     @test test_mqg_setqsetψ(dev)
-    @test test_mqg_setηxsetηy_nonperiodic(dev)
+    @test test_mqg_set_topographicPV_largescale_gradient(dev)
     @test test_mqg_paramsconstructor(dev)
     @test test_mqg_stochasticforcedproblemconstructor(dev)
     @test test_mqg_problemtype(dev, Float32)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,16 +27,16 @@ const rtol_surfaceqg = 1e-13 # tolerance for surfaceqg forcing tests
 # Run tests
 testtime = @elapsed begin
 for dev in devices
-  
+
   @info "testing on " * string(typeof(dev))
-  
+
   @testset "Utils" begin
     include("test_utils.jl")
 
     @test testpeakedisotropicspectrum(dev)
     @test_throws ErrorException("the domain is not square") testpeakedisotropicspectrum_rectangledomain()
   end
-  
+
   @testset "TwoDNavierStokes" begin
     include("test_twodnavierstokes.jl")
 
@@ -50,10 +50,10 @@ for dev in devices
     @test test_twodnavierstokes_problemtype(dev, Float32)
     @test TwoDNavierStokes.nothingfunction() == nothing
   end
-  
+
   @testset "SingleLayerQG" begin
     include("test_singlelayerqg.jl")
-    
+
     for deformation_radius in [Inf, 1.23]
       @test test_1layerqg_rossbywave("ETDRK4", 1e-2, 20, dev, deformation_radius=deformation_radius)
       @test test_1layerqg_rossbywave("FilteredETDRK4", 1e-2, 20, dev, deformation_radius=deformation_radius)
@@ -81,7 +81,7 @@ for dev in devices
     @test_throws ErrorException("not implemented for finite deformation radius") test_1layerqg_energy_drag(dev; deformation_radius=2.23)
     @test_throws ErrorException("not implemented for finite deformation radius") test_1layerqg_enstrophy_drag(dev; deformation_radius=2.23)
   end
-  
+
   @testset "BarotropicQGQL" begin
     include("test_barotropicqgql.jl")
 
@@ -100,10 +100,10 @@ for dev in devices
     @test test_bqgql_problemtype(dev, Float32)
     @test BarotropicQGQL.nothingfunction() == nothing
   end
-  
+
   @testset "SurfaceQG" begin
     include("test_surfaceqg.jl")
-      
+
     @test test_sqg_kineticenergy_buoyancyvariance(dev)
     @test test_sqg_advection(0.0005, "ForwardEuler", dev)
     @test test_sqg_deterministicforcing_buoyancy_variance_budget(dev)
@@ -114,10 +114,10 @@ for dev in devices
     @test test_sqg_noforcing(dev)
     @test SurfaceQG.nothingfunction() == nothing
   end
-  
+
   @testset "MultiLayerQG" begin
     include("test_multilayerqg.jl")
-    
+
     @test test_pvtofromstreamfunction_2layer(dev)
     @test test_pvtofromstreamfunction_3layer(dev)
     @test test_mqg_rossbywave("RK4", 1e-2, 20, dev)
@@ -128,6 +128,7 @@ for dev in devices
     @test test_mqg_fluxes(dev)
     @test test_mqg_fluxessinglelayer(dev)
     @test test_mqg_setqsetψ(dev)
+    @test test_mqg_setηxsetηy_nonperiodic(dev)
     @test test_mqg_paramsconstructor(dev)
     @test test_mqg_stochasticforcedproblemconstructor(dev)
     @test test_mqg_problemtype(dev, Float32)

--- a/test/test_multilayerqg.jl
+++ b/test/test_multilayerqg.jl
@@ -525,6 +525,7 @@ function test_mqg_setηxsetηy_nonperiodic(dev::Device=CPU(); dt=0.001, stepper=
   nx, ny = 32, 34
   L = 2π
   gr = TwoDGrid(dev; nx, Lx=L, ny, Ly=L)
+  T = eltype(gr)
 
   x, y = gridpoints(gr)
   k₀, l₀ = 2π/gr.Lx, 2π/gr.Ly    # fundamental wavenumbers
@@ -555,7 +556,7 @@ function test_mqg_setηxsetηy_nonperiodic(dev::Device=CPU(); dt=0.001, stepper=
   @. ηynonperiodic += f₀ * slope_y / H[2]
 
   prob = MultiLayerQG.Problem(nlayers, dev;
-                              nx, ny, Lx=L, Ly=L, f₀, g, H, ρ, U, μ, β=0,
+                              nx, ny, Lx=L, Ly=L, f₀, g, H, ρ, U, μ, β=0, T,
                               eta=ηperiodic,
                               etax_nonperiodic=ηxnonperiodic,
                               etay_nonperiodic=ηynonperiodic,

--- a/test/test_multilayerqg.jl
+++ b/test/test_multilayerqg.jl
@@ -48,7 +48,7 @@ function constructtestfields_3layer(gr)
   ψ1 = @. 1e-3 * ( 1/4*cos(2k₀*x)*cos(5l₀*y) + 1/3*cos(3k₀*x)*cos(3l₀*y) )
   ψ2 = @. 1e-3 * (     cos(3k₀*x)*cos(4l₀*y) + 1/2*cos(4k₀*x)*cos(2l₀*y) )
   ψ3 = @. 1e-3 * (     cos(1k₀*x)*cos(3l₀*y) + 1/2*cos(2k₀*x)*cos(2l₀*y) )
-  
+
   Δψ1 = @. -1e-3 * ( 1/4*((2k₀)^2+(5l₀)^2)*cos(2k₀*x)*cos(5l₀*y) + 1/3*((3k₀)^2+(3l₀)^2)*cos(3k₀*x)*cos(3l₀*y) )
   Δψ2 = @. -1e-3 * (     ((3k₀)^2+(4l₀)^2)*cos(3k₀*x)*cos(4l₀*y) + 1/2*((4k₀)^2+(2l₀)^2)*cos(4k₀*x)*cos(2l₀*y) )
   Δψ3 = @. -1e-3 * (     ((1k₀)^2+(3l₀)^2)*cos(1k₀*x)*cos(3l₀*y) + 1/2*((2k₀)^2+(2l₀)^2)*cos(2k₀*x)*cos(2l₀*y) )
@@ -111,7 +111,7 @@ Tests the pvfromstreamfunction function that gives qh from ψh. To do so, it
 constructs a 3-layer problem with parameters such that
   q1 = Δψ1 + 20ψ2 - 20ψ1, q2 = Δψ2 + 20ψ1 - 44ψ2 + 24ψ3, q3 = Δψ3 + 12ψ2 - 12ψ3.
 Then given ψ1, ψ2, and ψ2 it tests if pvfromstreamfunction gives the expected
-q1, q2, and q3. Similarly, that streamfunctionfrompv gives ψ1, ψ2, and ψ2 from 
+q1, q2, and q3. Similarly, that streamfunctionfrompv gives ψ1, ψ2, and ψ2 from
 q1, q2, and q3.
 """
 function test_pvtofromstreamfunction_3layer(dev::Device=CPU())
@@ -164,7 +164,7 @@ that a solution to the problem forced by this Ff is then qf.
 """
 function test_mqg_nonlinearadvection(dt, stepper, dev::Device=CPU();
                                      n=128, L=2π, nlayers=2, μ=0.0, ν=0.0, nν=1)
-  
+
   A = device_array(dev)
 
   tf = 0.5
@@ -181,9 +181,9 @@ function test_mqg_nonlinearadvection(dt, stepper, dev::Device=CPU();
   f₀, g = 1, 1      # desired PV-streamfunction relations
   H = [0.2, 0.8]    # q1 = Δψ1 + 25*(ψ2-ψ1), and
   ρ = [4.0, 5.0]    # q2 = Δψ2 + 25/4*(ψ1-ψ2).
-  
+
   β = 0.35
-  
+
   U1, U2 = 0.1, 0.05
   u1 = @. 0.5sech(gr.y/(Ly/15))^2; u1 = A(reshape(u1, (1, gr.ny)))
   u2 = @. 0.02cos(3l₀*gr.y);       u2 = A(reshape(u2, (1, gr.ny)))
@@ -234,12 +234,12 @@ function test_mqg_nonlinearadvection(dt, stepper, dev::Device=CPU();
   @views ψf[:, :, 2] = ψ2
 
   MultiLayerQG.set_q!(prob, qf)
-  
+
   stepforward!(prob, nt)
   MultiLayerQG.updatevars!(prob)
-  
+
   return isapprox(vs.q, qf, rtol=rtol_multilayerqg) &&
-         isapprox(vs.ψ, ψf, rtol=rtol_multilayerqg)		
+         isapprox(vs.ψ, ψf, rtol=rtol_multilayerqg)
 end
 
 """
@@ -255,9 +255,9 @@ is unstable.)
 """
 function test_mqg_linearadvection(dt, stepper, dev::Device=CPU();
                                   n=128, L=2π, nlayers=2, μ=0.0, ν=0.0, nν=1)
-  
+
   A = device_array(dev)
-  
+
   tf = 0.5
   nt = round(Int, tf/dt)
 
@@ -295,9 +295,9 @@ function test_mqg_linearadvection(dt, stepper, dev::Device=CPU();
 
   Ff1 = (β .- uyy1 .- 25*(U2.+u2.-U1.-u1) ).*ψ1x + (U1.+u1).*q1x - ν*Δq1
   Ff2 = FourierFlows.jacobian(ψ2, η, gr) + (β .- uyy2 .- 25/4*(U1.+u1.-U2.-u2) ).*ψ2x + (U2.+u2).*(q2x + ηx) + μ*Δψ2 - ν*Δq2
-  
+
   T = eltype(gr)
-  
+
   Ff = zeros(dev, T, (gr.nx, gr.ny, nlayers))
   @views Ff[:, :, 1] = Ff1
   @views Ff[:, :, 2] = Ff2
@@ -313,7 +313,7 @@ function test_mqg_linearadvection(dt, stepper, dev::Device=CPU();
 
   prob = MultiLayerQG.Problem(nlayers, dev; nx, ny, Lx, Ly, f₀, g, H, ρ, U,
                               eta=η, β, μ, ν, nν, calcFq=calcFq!, stepper, dt, linear=true)
-  
+
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   qf = zeros(dev, T, (gr.nx, gr.ny, nlayers))
@@ -348,16 +348,16 @@ function test_mqg_energies(dev::Device=CPU();
   x, y = gridpoints(gr)
   k₀, l₀ = 2π/gr.Lx, 2π/gr.Ly # fundamental wavenumbers
   nlayers = 2
-  
+
   f₀, g = 1, 1
   H = [2.5, 7.5] # sum(params.H) = 10
   ρ = [1.0, 2.0] # Make g′ = 1/2
-  
+
   prob = MultiLayerQG.Problem(nlayers, dev; nx, ny, Lx, Ly, f₀, g, H, ρ)
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   ψ = zeros(dev, eltype(gr), (gr.nx, gr.ny, nlayers))
-  
+
   CUDA.@allowscalar @views @. ψ[:, :, 1] =       cos(2k₀ * x) * cos(2l₀ * y)
   CUDA.@allowscalar @views @. ψ[:, :, 2] = 1/2 * cos(2k₀ * x) * cos(2l₀ * y)
 
@@ -380,10 +380,10 @@ function test_mqg_energysinglelayer(dev::Device=CPU();
   nx, Lx  = 64, 2π
   ny, Ly  = 64, 3π
   gr = TwoDGrid(dev; nx, Lx, ny, Ly)
-  
+
   x, y = gridpoints(gr)
   k₀, l₀ = 2π/gr.Lx, 2π/gr.Ly # fundamental wavenumbers
-  
+
   energy_calc = 29/9
 
   ψ0 = @. sin(2k₀*x)*cos(2l₀*y) + 2sin(k₀*x)*cos(3l₀*y)
@@ -439,12 +439,12 @@ end
 """
     test_mqg_fluxessinglelayer(dt, stepper; kwargs...)
 
-Tests the lateral eddy fluxes by constructing a 1-layer problem and initializing 
+Tests the lateral eddy fluxes by constructing a 1-layer problem and initializing
 it with a flow field whose fluxes are known.
 """
-function test_mqg_fluxessinglelayer(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler", n=128, L=2π, μ=0.0, ν=0.0, nν=1) 
+function test_mqg_fluxessinglelayer(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler", n=128, L=2π, μ=0.0, ν=0.0, nν=1)
   nlayers = 1
-  
+
   nx, ny = 128, 126
   Lx, Ly = 2π, 2π
   gr = TwoDGrid(dev; nx, Lx, ny, Ly)
@@ -486,11 +486,11 @@ function test_mqg_setqsetψ(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler",
   ρ = [4.0, 5.0]    # q2 = Δψ2 + 25/4*(ψ1-ψ2).
 
   prob = MultiLayerQG.Problem(nlayers, dev; nx, ny, Lx=L, f₀, g, H, ρ)
-  
+
   sol, cl, pr, vs, gr = prob.sol, prob.clock, prob.params, prob.vars, prob.grid
 
   T = eltype(gr)
-  
+
   f1 = @. 2cos(k₀*x)*cos(l₀*y)
   f2 = @.  cos(k₀*x+π/10)*cos(2l₀*y)
   f = zeros(dev, T, (gr.nx, gr.ny, nlayers))
@@ -513,6 +513,74 @@ function test_mqg_setqsetψ(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler",
 end
 
 """
+    test_setηxsetηy_nonperiodic(dt, stepper; kwargs...)
+
+Ensures that the error of setting a topographic PV field η that has both periodic
+and non-perodic components is small. The PV gradients associated with the periodic
+part are calculated spectrally from the topographic PV field `eta`, while the
+PV gradients associated with the non-periodic part are specified separately as
+`etax_nonperiodic` and `etay_nonperiodic`.
+"""
+function test_mqg_setηxsetηy_nonperiodic(dev::Device=CPU(); dt=0.001, stepper="ForwardEuler", n=64, L=2π, nlayers=2, μ=0.0, ν=0.0, nν=1)
+  nx, ny = 32, 34
+  L = 2π
+  gr = TwoDGrid(dev; nx, Lx=L, ny, Ly=L)
+
+  x, y = gridpoints(gr)
+  k₀, l₀ = 2π/gr.Lx, 2π/gr.Ly # fundamental wavenumbers
+
+  nlayers = 2        # these choice of parameters give the
+  f₀, g = 1, 1       # desired PV-streamfunction relations
+  H = [0.2, 0.8]     # q1 = Δψ1 + 25*(ψ2-ψ1), and
+  ρ = [4.0, 5.0]     # q2 = Δψ2 + 25/4*(ψ1-ψ2).
+  U = zeros(nlayers) # the imposed mean zonal flow in each layer
+  U[1] = 1.0
+  U[2] = 0.0
+  h₀ = 0.1
+  sx = 1e-2
+  sy = 1e-1
+
+  hnonperiodic = zeros(nx, ny)
+  hperiodic = zeros(nx, ny)
+  @. hnonperiodic += sx*x + sy*y         # Non-periodic part of topography (slope).
+  @. hperiodic += h₀*cos(k₀*x)*cos(l₀*y) # Periodic part of topography (bumps).
+  ηnonperiodic = f₀*hnonperiodic/H[2]
+  ηperiodic = f₀*hperiodic/H[2]
+
+  # Non-periodic part of topographic PV gradients (slope).
+  ηxnonperiodic = zeros(nx, ny)
+  ηynonperiodic = zeros(nx, ny)
+  @. ηxnonperiodic += f₀*sx/H[2]
+  @. ηynonperiodic += f₀*sy/H[2]
+
+  prob = MultiLayerQG.Problem(nlayers, dev;
+                              nx=nx, ny=ny, Lx=L, Ly=L,
+                              f₀=f₀, g=g, H=H, ρ=ρ, U=U, μ=μ, β=0,
+                              eta=ηperiodic,
+                              etax_nonperiodic=ηxnonperiodic,
+                              etay_nonperiodic=ηynonperiodic,
+                              linear=false,
+                              dt=dt, stepper=stepper, aliased_fraction=0)
+  params = prob.params
+
+  # Test to see if the internally-computed total bottom Qx and Qy are correct.
+  Q2y_ana = zeros(nx, ny)
+  Q2x_ana = zeros(nx, ny)
+  gp = g*(ρ[2] - ρ[1])/ρ[2]
+  F1 = f₀^2/(H[2]*gp)
+  Psi1y, Psi2y = - U[1], - U[2]
+  @. Q2y_ana += - f₀*h₀*l₀*cos(k₀*x)*sin(l₀*y)/H[2] + F1*(Psi1y - Psi2y)
+  @. Q2x_ana += - f₀*h₀*k₀*sin(k₀*x)*cos(l₀*y)/H[2]
+
+  Q2x_ana += ηxnonperiodic
+  Q2y_ana += ηynonperiodic
+  nxh, nyh = Int(nx/2), Int(ny/2)
+
+return isapprox(params.Qx[:, nxh, 2], Q2x_ana[:, nxh], rtol=rtol_multilayerqg) &&
+       isapprox(params.Qy[nyh, :, 2], Q2y_ana[nyh, :], rtol=rtol_multilayerqg)
+end
+
+"""
     test_paramsconstructor(; kwargs...)
 
 Tests that `Params` constructor works with both mean flow `U` being a floats
@@ -527,11 +595,11 @@ function test_mqg_paramsconstructor(dev::Device=CPU(); dt=0.001, stepper="Forwar
   f₀, g = 1, 1      # desired PV-streamfunction relations
   H = [0.2, 0.8]    # q1 = Δψ1 + 25*(ψ2-ψ1), and
   ρ = [4.0, 5.0]    # q2 = Δψ2 + 25/4*(ψ1-ψ2).
-  
+
   U1, U2 = 0.1, 0.05
 
   T = eltype(gr)
-  
+
   Uvectors = zeros(dev, T, (ny, nlayers))
   Uvectors[:, 1] .= U1
   Uvectors[:, 2] .= U2
@@ -549,9 +617,9 @@ end
 function test_mqg_problemtype(dev, T)
   prob1 = MultiLayerQG.Problem(1, dev; T)
   prob2 = MultiLayerQG.Problem(2, dev; T)
-  
+
   A = device_array(dev)
-  
+
   return typeof(prob1.sol)<:A{Complex{T}, 3} &&
          typeof(prob1.grid.Lx)==T &&
          typeof(prob1.vars.u)<:A{T, 3} &&
@@ -562,7 +630,7 @@ end
 """
     test_mqg_rossbywave(; kwargs...)
 
-Evolves a Rossby wave on a beta plane with an imposed zonal flow U and compares 
+Evolves a Rossby wave on a beta plane with an imposed zonal flow U and compares
 with the analytic solution.
 """
 function test_mqg_rossbywave(stepper, dt, nsteps, dev::Device=CPU())
@@ -599,19 +667,19 @@ end
 function test_numberoflayers(dev::Device=CPU())
   prob_nlayers1 = MultiLayerQG.Problem(1, dev)
   prob_nlayers2 = MultiLayerQG.Problem(2, dev)
-  
+
   return MultiLayerQG.numberoflayers(prob_nlayers1)==1 &&
          MultiLayerQG.numberoflayers(prob_nlayers2)==2
 end
 
 function test_mqg_stochasticforcedproblemconstructor(dev::Device=CPU())
-  
+
   function calcFq!(Fqh, sol, t, clock, vars, params, grid)
     Fqh .= Ffh
     return nothing
   end
-       
+
   prob = MultiLayerQG.Problem(2, dev; calcFq=calcFq!, stochastic=true)
-  
+
   return typeof(prob.vars.prevsol)==typeof(prob.sol)
 end

--- a/test/test_multilayerqg.jl
+++ b/test/test_multilayerqg.jl
@@ -540,18 +540,17 @@ function test_mqg_setηxsetηy_nonperiodic(dev::Device=CPU(); dt=0.001, stepper=
   h₀ = 0.1                       # topographic amplituce
   slope_x, slope_y = 1e-2, 1e-1  # large-scale topographic gradients
 
-  hnonperiodic = zeros(dev, T, nx, ny)
-     hperiodic = zeros(dev, T, nx, ny)
+  hnonperiodic = zeros(dev, T, (nx, ny))
+     hperiodic = zeros(dev, T, (nx, ny))
 
-  @. hnonperiodic += slope_x * x + slope_y * y   # Non-periodic part of topography (slope).
-  @.    hperiodic += h₀ * cos(k₀*x) * cos(l₀*y)  # Periodic part of topography (bumps).
+  @. hnonperiodic += slope_x * x + slope_y * y   # non-periodic part of topography (slope)
+  @.    hperiodic += h₀ * cos(k₀*x) * cos(l₀*y)  # periodic part of topography (bumps)
 
-  ηnonperiodic = f₀ * hnonperiodic / H[2]
      ηperiodic = f₀ * hperiodic / H[2]
 
-  # Non-periodic part of topographic PV gradients (slope).
-  ηxnonperiodic = zeros(dev, T, nx, ny)
-  ηynonperiodic = zeros(dev, T, nx, ny)
+  # Non-periodic part of topographic PV gradients (slope)
+  ηxnonperiodic = zeros(dev, T, (nx, ny))
+  ηynonperiodic = zeros(dev, T, (nx, ny))
   @. ηxnonperiodic += f₀ * slope_x / H[2]
   @. ηynonperiodic += f₀ * slope_y / H[2]
 
@@ -560,13 +559,12 @@ function test_mqg_setηxsetηy_nonperiodic(dev::Device=CPU(); dt=0.001, stepper=
                               eta=ηperiodic,
                               etax_nonperiodic=ηxnonperiodic,
                               etay_nonperiodic=ηynonperiodic,
-                              linear=false,
                               dt, stepper, aliased_fraction=0)
   params = prob.params
 
-  # Test to see if the internally-computed total bottom Qx and Qy are correct.
-  Q2y_analytic = zeros(dev, T, nx, ny)
-  Q2x_analytic = zeros(dev, T, nx, ny)
+  # Test to see if the internally-computed total bottom Qx and Qy are correct
+  Q2y_analytic = zeros(dev, T, (nx, ny))
+  Q2x_analytic = zeros(dev, T, (nx, ny))
 
   g′ = g * (ρ[2] - ρ[1]) / ρ[2]
   F1 = f₀^2 / (H[2] * g′)
@@ -577,10 +575,9 @@ function test_mqg_setηxsetηy_nonperiodic(dev::Device=CPU(); dt=0.001, stepper=
 
   Q2x_analytic += ηxnonperiodic
   Q2y_analytic += ηynonperiodic
-  nxh, nyh = Int(nx/2), Int(ny/2)
 
-return isapprox(params.Qx[:, nxh, 2], Q2x_analytic[:, nxh], rtol=rtol_multilayerqg) &&
-       isapprox(params.Qy[nyh, :, 2], Q2y_analytic[nyh, :], rtol=rtol_multilayerqg)
+return isapprox(params.Qx[:, :, 2], Q2x_analytic, rtol=rtol_multilayerqg) &&
+       isapprox(params.Qy[:, :, 2], Q2y_analytic, rtol=rtol_multilayerqg)
 end
 
 """


### PR DESCRIPTION
This closes #307 by adding options to specify a nonperiodic component of the topographic PV gradients (for example a planar slope) in the `MultiLayerQG` module. Also added one test.

The gradients of the nonperiodic part of the topographic PV are now specified separately via `etax_nonperiodic` and `etay_nonperiodic` in `MultiLayerQG.Problem`, and are added to the gradients of the periodic part of the topographic PV (calculated via FFTs).