### PR TITLE
Faster and with reduced memory allocations `calcF!` function in examples with stochastic noise

### DIFF
--- a/docs/src/visualize.md
+++ b/docs/src/visualize.md
@@ -1,17 +1,16 @@
 # Visualize output
 
-In the examples we use [Makie.jl](https://makie.juliaplots.org/stable/) for plotting.
+In the examples we use [Makie.jl](https://docs.makie.org/stable/) for plotting.
 
-Makie comes with a few [backends](https://makie.juliaplots.org/stable/#makie_ecosystem). In the documented examples
-we use [CairoMakie](https://makie.juliaplots.org/stable/documentation/backends/cairomakie/) since this backend
+Makie comes with a few [backends](https://docs.makie.org/stable/#makie_ecosystem). In the documented examples
+we use [CairoMakie](https://docs.makie.org/stable/documentation/backends/cairomakie/) since this backend
 works well on headless devices, that is, devices without monitor. Since the documentation is automatically
 built via GitHub actions the CairoMakie backend is necessary. Users that run GeophysicalFlows.jl on
-devices with a monitor might want to change to [GLMakie](https://makie.juliaplots.org/stable/documentation/backends/glmakie/)
+devices with a monitor might want to change to [GLMakie](https://docs.makie.org/stable/documentation/backends/glmakie/)
 that displays figures in an interactive window.
 
-In GeophysicalFlows.jl simulations, we can either visualize the flow on-the-fly as the problem is stepped forward or
-we can save output onto `.jld2` and after simulation is done load the output and visualize it. Most examples use the
-former strategy. For a demonstration for how one can save output and load later to process/visualize look at the
-[`SingeLayerQG` beta-plane forced-dissipative example](@ref singlelayerqg_betaforced_example). Furthermore, the
-[Output section](https://fourierflows.github.io/FourierFlowsDocumentation/stable/output/) in FourierFlows.jl Documentation
-might be useful.
+In GeophysicalFlows.jl simulations, we can either visualize the fields on-the-fly as the problem is stepped forward or
+we can save output onto a `.jld2` fileand after simulation is done load the output and visualize it. Most examples do
+the former. For a demonstration for how one can save output and load later to process and visualize it have a look at the
+[`SingeLayerQG` beta-plane forced-dissipative example](@ref singlelayerqg_betaforced_example). Regarding saving output to `.jld2` files, the [Output section](https://fourierflows.github.io/FourierFlowsDocumentation/stable/output/) in FourierFlows.jl
+Documentation might be useful.

--- a/docs/src/visualize.md
+++ b/docs/src/visualize.md
@@ -10,7 +10,9 @@ devices with a monitor might want to change to [GLMakie](https://docs.makie.org/
 that displays figures in an interactive window.
 
 In GeophysicalFlows.jl simulations, we can either visualize the fields on-the-fly as the problem is stepped forward or
-we can save output onto a `.jld2` fileand after simulation is done load the output and visualize it. Most examples do
+we can save output onto a `.jld2` file and after simulation is done load the output and visualize it. Most examples do
 the former. For a demonstration for how one can save output and load later to process and visualize it have a look at the
-[`SingeLayerQG` beta-plane forced-dissipative example](@ref singlelayerqg_betaforced_example). Regarding saving output to `.jld2` files, the [Output section](https://fourierflows.github.io/FourierFlowsDocumentation/stable/output/) in FourierFlows.jl
-Documentation might be useful.
+[`SingeLayerQG` beta-plane forced-dissipative example](@ref singlelayerqg_betaforced_example). For more information about
+saving output to `.jld2` files, files see the
+[Output section](https://fourierflows.github.io/FourierFlowsDocumentation/stable/output/) in FourierFlows.jl Documentation
+might be useful.

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -86,7 +86,7 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform()) / sqrt(clock.dt)
+  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform(eltype(grid))) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -85,8 +85,8 @@ nothing # hide
 # numbers uniformly distributed between 0 and 1.
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
-function calcF!(Fh, sol, t, clock, vars, params, grid) 
-  Fh .= sqrt.(forcing_spectrum) .* exp.(2π * im * random_uniform(eltype(grid), size(sol))) ./ sqrt(clock.dt)
+function calcF!(Fh, sol, t, clock, vars, params, grid)
+  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform()) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -23,7 +23,8 @@ using GeophysicalFlows, CUDA, Random, Printf, CairoMakie
 using Statistics: mean
 
 parsevalsum = FourierFlows.parsevalsum
-record = CairoMakie.record
+record = CairoMakie.record                # disambiguate between CairoMakie.record and CUDA.record
+nothing # hide
 
 # ## Choosing a device: CPU or GPU
 

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -86,7 +86,7 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform(eltype(grid))) / sqrt(clock.dt)
+  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(eltype(grid))) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/barotropicqgql_betaforced.jl
+++ b/examples/barotropicqgql_betaforced.jl
@@ -86,7 +86,8 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(eltype(grid))) / sqrt(clock.dt)
+  T = eltype(grid)
+  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(T)) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -87,7 +87,7 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform()) / sqrt(clock.dt)
+  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform(eltype(grid))) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -87,7 +87,7 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform(eltype(grid))) / sqrt(clock.dt)
+  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(eltype(grid))) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -86,8 +86,8 @@ nothing # hide
 # numbers uniformly distributed between 0 and 1.
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
-function calcF!(Fh, sol, t, clock, vars, params, grid) 
-  Fh .= sqrt.(forcing_spectrum) .* exp.(2π * im * random_uniform(eltype(grid), size(sol))) ./ sqrt(clock.dt)
+function calcF!(Fh, sol, t, clock, vars, params, grid)
+  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform()) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -23,7 +23,8 @@ using Statistics: mean
 using LinearAlgebra: ldiv!
 
 parsevalsum = FourierFlows.parsevalsum
-record = CairoMakie.record
+record = CairoMakie.record                # disambiguate between CairoMakie.record and CUDA.record
+nothing # hide
 
 # ## Choosing a device: CPU or GPU
 

--- a/examples/singlelayerqg_betaforced.jl
+++ b/examples/singlelayerqg_betaforced.jl
@@ -87,7 +87,8 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(eltype(grid))) / sqrt(clock.dt)
+  T = eltype(grid)
+  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(T)) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -79,7 +79,7 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform()) / sqrt(clock.dt)
+  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform(eltype(grid))) / sqrt(clock.dt)
   
   return nothing
 end

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -79,7 +79,7 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform(eltype(grid))) / sqrt(clock.dt)
+  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(eltype(grid))) / sqrt(clock.dt)
   
   return nothing
 end

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -21,7 +21,8 @@
 using GeophysicalFlows, CUDA, Random, Printf, CairoMakie
 
 parsevalsum = FourierFlows.parsevalsum
-record = CairoMakie.record
+record = CairoMakie.record                # disambiguate between CairoMakie.record and CUDA.record
+nothing # hide
 
 # ## Choosing a device: CPU or GPU
 

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -79,7 +79,8 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(eltype(grid))) / sqrt(clock.dt)
+  T = eltype(grid)
+  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(T)) / sqrt(clock.dt)
   
   return nothing
 end

--- a/examples/twodnavierstokes_stochasticforcing.jl
+++ b/examples/twodnavierstokes_stochasticforcing.jl
@@ -78,8 +78,8 @@ nothing # hide
 # numbers uniformly distributed between 0 and 1.
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
-function calcF!(Fh, sol, t, clock, vars, params, grid) 
-  Fh .= sqrt.(forcing_spectrum) .* exp.(2π * im * random_uniform(eltype(grid), size(sol))) ./ sqrt(clock.dt)
+function calcF!(Fh, sol, t, clock, vars, params, grid)
+  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform()) / sqrt(clock.dt)
   
   return nothing
 end

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -81,7 +81,7 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform()) / sqrt(clock.dt)
+  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform(eltype(grid))) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -80,8 +80,8 @@ nothing # hide
 # numbers uniformly distributed between 0 and 1.
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
-function calcF!(Fh, sol, t, clock, vars, params, grid) 
-  Fh .= sqrt.(forcing_spectrum) .* exp.(2π * im * random_uniform(eltype(grid), size(sol))) ./ sqrt(clock.dt)
+function calcF!(Fh, sol, t, clock, vars, params, grid)
+  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform()) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -81,7 +81,7 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform(eltype(grid))) / sqrt(clock.dt)
+  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(eltype(grid))) / sqrt(clock.dt)
 
   return nothing
 end

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -23,7 +23,8 @@
 using GeophysicalFlows, CUDA, Random, Printf, CairoMakie
 
 parsevalsum = FourierFlows.parsevalsum
-record = CairoMakie.record
+record = CairoMakie.record                # disambiguate between CairoMakie.record and CUDA.record
+nothing # hide
 
 # ## Choosing a device: CPU or GPU
 

--- a/examples/twodnavierstokes_stochasticforcing_budgets.jl
+++ b/examples/twodnavierstokes_stochasticforcing_budgets.jl
@@ -81,7 +81,8 @@ nothing # hide
 random_uniform = dev==CPU() ? rand : CUDA.rand
 
 function calcF!(Fh, sol, t, clock, vars, params, grid)
-  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(eltype(grid))) / sqrt(clock.dt)
+  T = eltype(grid)
+  @. Fh = sqrt(forcing_spectrum) * cis(2π * random_uniform(T)) / sqrt(clock.dt)
 
   return nothing
 end


### PR DESCRIPTION
This PR makes the `calcF!` functions for stochastic forcing faster and with fewer allocations.

```Julia
julia> using BenchmarkTools

julia> function calcF!(Fh, sol, t, clock, vars, params, grid)
         Fh .= sqrt.(forcing_spectrum) .* exp.(2π * im * random_uniform(eltype(grid), size(sol))) ./ sqrt(clock.dt)

         return nothing
       end
calcF! (generic function with 1 method)

julia> function calcF_new!(Fh, sol, t, clock, vars, params, grid)
         @. Fh = sqrt(forcing_spectrum) * cis(2random_uniform()) / sqrt(clock.dt)

         return nothing
       end
calcF_new! (generic function with 1 method)

julia> @btime calcF!(Fh, sol, t, clock, vars, params, grid)
  152.208 μs (14 allocations: 195.33 KiB)

julia> @btime calcF_new!(Fh, sol, t, clock, vars, params, grid)
  111.416 μs (11 allocations: 240 bytes)
```

The PR also fixes some links to Makie package in the docs.