### PR TITLE
Add Siegelman & Young 2023 + use Documenter v1

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.6
+          version: 1.9
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.8'
+          version: '1.9'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -9,4 +9,5 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 [compat]
 CairoMakie = "< 0.10.5"
 CUDA = "1, 2.4.2, 3.0.0 - 3.6.4, 3.7.1, 4"
+Documenter = "0.27"
 Literate = "≥2.9.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,7 +7,7 @@ Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-CairoMakie = "< 0.10.5"
 CUDA = "1, 2.4.2, 3.0.0 - 3.6.4, 3.7.1, 4"
-Documenter = "0.27"
+CairoMakie = "< 0.10.5"
+Documenter = "1"
 Literate = "≥2.9.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -48,55 +48,55 @@ format = Documenter.HTML(
 )
 
 makedocs(
- modules = [GeophysicalFlows],
- doctest = true,
-   clean = true,
+  modules = [GeophysicalFlows],
+  doctest = true,
+    clean = true,
 checkdocs = :all,
-  format = format,
- authors = "Navid C. Constantinou, Gregory L. Wagner, and contributors",
-sitename = "GeophysicalFlows.jl",
-   pages = Any[
-            "Home" => "index.md",
-            "Installation instructions" => "installation_instructions.md",
-            "Aliasing" => "aliasing.md",
-            "GPU" => "gpu.md",
-            "Visualize output" => "visualize.md",
-            "Examples" => [
-              "TwoDNavierStokes" => Any[
-                "literated/twodnavierstokes_decaying.md",
-                "literated/twodnavierstokes_stochasticforcing.md",
-                "literated/twodnavierstokes_stochasticforcing_budgets.md",
-                ],
-              "SingleLayerQG" => Any[
-                "literated/singlelayerqg_betadecay.md",
-                "literated/singlelayerqg_betaforced.md",
-                "literated/singlelayerqg_decaying_topography.md",
-                "literated/singlelayerqg_decaying_barotropic_equivalentbarotropic.md"
-                ],
-              "BarotropicQGQL" => Any[
-                "literated/barotropicqgql_betaforced.md",
-                ],
-              "MultiLayerQG" => Any[
-                "literated/multilayerqg_2layer.md"
-                ],
-              "SurfaceQG" => Any[
-                "literated/surfaceqg_decaying.md"
+   format = format,
+  authors = "Navid C. Constantinou, Gregory L. Wagner, and contributors",
+ sitename = "GeophysicalFlows.jl",
+    pages = Any[
+                "Home" => "index.md",
+                "Installation instructions" => "installation_instructions.md",
+                "Aliasing" => "aliasing.md",
+                "GPU" => "gpu.md",
+                "Visualize output" => "visualize.md",
+                "Examples" => [
+                  "TwoDNavierStokes" => Any[
+                    "literated/twodnavierstokes_decaying.md",
+                    "literated/twodnavierstokes_stochasticforcing.md",
+                    "literated/twodnavierstokes_stochasticforcing_budgets.md",
+                    ],
+                  "SingleLayerQG" => Any[
+                    "literated/singlelayerqg_betadecay.md",
+                    "literated/singlelayerqg_betaforced.md",
+                    "literated/singlelayerqg_decaying_topography.md",
+                    "literated/singlelayerqg_decaying_barotropic_equivalentbarotropic.md"
+                    ],
+                  "BarotropicQGQL" => Any[
+                    "literated/barotropicqgql_betaforced.md",
+                    ],
+                  "MultiLayerQG" => Any[
+                    "literated/multilayerqg_2layer.md"
+                    ],
+                  "SurfaceQG" => Any[
+                    "literated/surfaceqg_decaying.md"
+                    ]
+                  ],
+                "Modules" => Any[
+                  "modules/twodnavierstokes.md",
+                  "modules/singlelayerqg.md",
+                  "modules/barotropicqgql.md",
+                  "modules/multilayerqg.md",
+                  "modules/surfaceqg.md"
+                  ],
+                "Stochastic forcing" => "stochastic_forcing.md",
+                "Contributor's guide" => "contributing.md",
+                "Library" => Any[
+                  "lib/types.md",
+                  "lib/functions.md"
                 ]
-            ],
-            "Modules" => Any[
-              "modules/twodnavierstokes.md",
-              "modules/singlelayerqg.md",
-              "modules/barotropicqgql.md",
-              "modules/multilayerqg.md",
-              "modules/surfaceqg.md"
-            ],
-            "Stochastic forcing" => "stochastic_forcing.md",
-            "Contributor's guide" => "contributing.md",
-            "Library" => Any[
-              "lib/types.md",
-              "lib/functions.md"
-            ]
-           ]
+              ]
 )
 
 @info "Clean up temporary .jld2 and .nc output created by doctests or literated examples..."

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -84,6 +84,8 @@ The bibtex entry for the paper is:
 
 ## Papers using `GeophysicalFlows.jl`
 
+1. Siegelman, L. and Young, W. R. (2023). Two-dimensional turbulence above topography: Vortices and potential vorticity homogenization. _Proceedings of the National Academy of Sciences_, **120(44)**, e2308018120, doi:[10.1073/pnas.2308018120](https://doi.org/10.1073/pnas.2308018120).
+
 1. Bisits, J. I., Stanley G. J., and Zika, J. D. (2023). Can we accurately quantify a lateral diffusivity using a single tracer release? _Journal of Physical Oceanography_, **53(2)**, 647–659, doi:[10.1175/JPO-D-22-0145.1](https://doi.org/10.1175/JPO-D-22-0145.1).
 
 1. Siegelman, L., Young, W. R., and Ingersoll, A. P. (2022). Polar vortex crystals: Emergence and structure _Proceedings of the National Academy of Sciences_, **119(17)**, e2120486119. doi:[10.1073/pnas.2120486119](https://doi.org/10.1073/pnas.2120486119).

--- a/docs/src/installation_instructions.md
+++ b/docs/src/installation_instructions.md
@@ -5,7 +5,7 @@ You can install the latest version of GeophysicalFlows.jl via the built-in packa
 instantiate/build all the required dependencies
 
 ```julia
-julia>]
+julia> ]
 (v1.6) pkg> add GeophysicalFlows
 (v1.6) pkg> instantiate
 ```
@@ -29,7 +29,4 @@ more than happy to help with getting your simulations up and running.
     of GeophysicalFlows.jl (the latest version compatible with your version of Julia).
     
     Last version compatible with Julia v1.5: GeophysicalFlows.jl v0.13.1
-
-    Last version compatible with Julia v1.0.5 (the current long-term-release): GeophysicalFlows.jl v0.5.1
-
 

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -22,6 +22,7 @@ GeophysicalFlows.TwoDNavierStokes.energy_work
 GeophysicalFlows.TwoDNavierStokes.enstrophy_dissipation_hyperviscosity
 GeophysicalFlows.TwoDNavierStokes.enstrophy_dissipation_hypoviscosity
 GeophysicalFlows.TwoDNavierStokes.enstrophy_work
+GeophysicalFlows.TwoDNavierStokes.palinstrophy
 ```
 
 ### Private functions

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -1,6 +1,9 @@
 # Functions
 
 ## `GeophysicalFlows`
+```@docs
+GeophysicalFlows.GeophysicalFlows
+```
 
 ### Exported functions
 

--- a/examples/singlelayerqg_betadecay.jl
+++ b/examples/singlelayerqg_betadecay.jl
@@ -31,7 +31,7 @@ nothing #hide
 stepper = "FilteredRK4"  # timestepper
      dt = 0.04           # timestep
  nsteps = 2000           # total number of time-steps
- nsubs  = 20             # number of time-steps for intermediate logging/plotting (nsteps must be multiple of nsubs)
+ nsubs  = 10             # number of time-steps for intermediate logging/plotting (nsteps must be multiple of nsubs)
 nothing #hide
 
 
@@ -201,7 +201,7 @@ startwalltime = time()
 
 frames = 0:round(Int, nsteps / nsubs)
 
-record(fig, "singlelayerqg_betadecay.mp4", frames, framerate = 8) do j
+record(fig, "singlelayerqg_betadecay.mp4", frames, framerate = 12) do j
   if j % round(Int, nsteps/nsubs / 4) == 0
     cfl = clock.dt * maximum([maximum(vars.u) / grid.dx, maximum(vars.v) / grid.dy])
 

--- a/examples/singlelayerqg_decaying_topography.jl
+++ b/examples/singlelayerqg_decaying_topography.jl
@@ -1,4 +1,4 @@
-# # [Decaying barotropic QG turbulence over topography](@id singlelayerqg_decaying_topography)
+# # [Decaying barotropic QG turbulence over topography](@id singlelayerqg_decay_topography_example)
 #
 # An example of decaying barotropic quasi-geostrophic turbulence over topography.
 #


### PR DESCRIPTION
This PR updates Docs to use Documenter v1 and adds Siegelman & Young 2023 in the list of papers that use this package.