### PR TITLE
Docs dev appear just after stable in the list of available versions

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -127,7 +127,7 @@ end
 
 withenv("GITHUB_REPOSITORY" => "FourierFlows/GeophysicalFlowsDocumentation") do
   deploydocs(       repo = "github.com/FourierFlows/GeophysicalFlowsDocumentation.git",
-                versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
+                versions = ["stable" => "v^", "dev" => "dev", "v#.#.#"],
             push_preview = false,
                forcepush = true,
                devbranch = "main"

--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -20,7 +20,7 @@
 
 @article{McWilliams-1984,
   title={The emergence of isolated coherent vortices in turbulent flow},
-  author={Mcwilliams, James C.},
+  author={McWilliams, James C.},
   journal={Journal of Fluid Mechanics},
   volume={146},
   pages={21--43},


### PR DESCRIPTION
This PR makes `dev` version of docs appear just after `stable`.