### PR TITLE
Add Parfenyev (2022, 2023) papers

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -100,6 +100,6 @@ The bibtex entry for the paper is:
 
 1. Drivas, T. D. and Elgindi, T. M. (2022). Singularity formation in the incompressible Euler equation in finite and infinite time. arXiv preprint arXiv:2203.17221, doi:[10.48550/arXiv.2203.17221](https://doi.org/10.48550/arXiv.2203.17221).
 
-1. Palóczy, A., and LaCasce, J. H. (2022). Instability of a surface jet over rough topography. _Journal of Physical Oceanography_, **52(11)**, 2725-2740, doi:[10.1175/JPO-D-22-0079.1](https://doi.org/10.1175/JPO-D-22-0079.1).
+1. Palóczy, A. and LaCasce, J. H. (2022). Instability of a surface jet over rough topography. _Journal of Physical Oceanography_, **52(11)**, 2725-2740, doi:[10.1175/JPO-D-22-0079.1](https://doi.org/10.1175/JPO-D-22-0079.1).
 
-1. Karrasch, D., and Schilling, N. (2020). Fast and robust computation of coherent Lagrangian vortices on very large two-dimensional domains. _The SMAI Journal of Computational Mathematics_, **6**, 101-124, doi:[10.5802/smai-jcm.63](https://doi.org/10.5802/smai-jcm.63).
+1. Karrasch, D. and Schilling, N. (2020). Fast and robust computation of coherent Lagrangian vortices on very large two-dimensional domains. _The SMAI Journal of Computational Mathematics_, **6**, 101-124, doi:[10.5802/smai-jcm.63](https://doi.org/10.5802/smai-jcm.63).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -84,6 +84,8 @@ The bibtex entry for the paper is:
 
 ## Papers using `GeophysicalFlows.jl`
 
+1. Parfenyev, V. (2023) Statistical analysis of vortex condensate motion in two-dimensional turbulence. arXiv preprint arXiv:2311.03065, doi:[10.48550/arXiv.2311.03065](https://doi.org/10.48550/arXiv.2311.03065).
+
 1. Shokar, I. J. S., Kerswell, R. R., and Haynes, P. H. (2023) Stochastic latent transformer: Efficient modelling of stochastically forced zonal jets. arXiv preprint arXiv:2310.16741, doi:[10.48550/arXiv.2310.16741](https://doi.org/10.48550/arXiv.2310.16741).
 
 1. Siegelman, L. and Young, W. R. (2023). Two-dimensional turbulence above topography: Vortices and potential vorticity homogenization. _Proceedings of the National Academy of Sciences_, **120(44)**, e2308018120, doi:[10.1073/pnas.2308018120](https://doi.org/10.1073/pnas.2308018120).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -88,7 +88,7 @@ The bibtex entry for the paper is:
 
 1. Shokar, I. J. S., Kerswell, R. R., and Haynes, P. H. (2023) Stochastic latent transformer: Efficient modelling of stochastically forced zonal jets. arXiv preprint arXiv:2310.16741, doi:[10.48550/arXiv.2310.16741](https://doi.org/10.48550/arXiv.2310.16741).
 
-1. Siegelman, L. and Young, W. R. (2023). Two-dimensional turbulence above topography: Vortices and potential vorticity homogenization. _Proceedings of the National Academy of Sciences_, **120(44)**, e2308018120. doi:[10.1073/pnas.2308018120](https://doi.org/10.1073/pnas.2308018120).
+1. Siegelman, L. and Young, W. R. (2023). Two-dimensional turbulence above topography: Vortices and potential vorticity homogenization. _Proceedings of the National Academy of Sciences_, **120(44)**, e2308018120, doi:[10.1073/pnas.2308018120](https://doi.org/10.1073/pnas.2308018120).
 
 1. Bisits, J. I., Stanley G. J., and Zika, J. D. (2023). Can we accurately quantify a lateral diffusivity using a single tracer release? _Journal of Physical Oceanography_, **53(2)**, 647–659, doi:[10.1175/JPO-D-22-0145.1](https://doi.org/10.1175/JPO-D-22-0145.1).
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -92,6 +92,8 @@ The bibtex entry for the paper is:
 
 1. Bisits, J. I., Stanley G. J., and Zika, J. D. (2023). Can we accurately quantify a lateral diffusivity using a single tracer release? _Journal of Physical Oceanography_, **53(2)**, 647–659, doi:[10.1175/JPO-D-22-0145.1](https://doi.org/10.1175/JPO-D-22-0145.1).
 
+1. Parfenyev, V. (2022) Profile of a two-dimensional vortex condensate beyond the universal limit. *Phys. Rev. E*, **106**, 025102, doi:[10.1103/PhysRevE.106.025102](https://doi.org/10.1103/PhysRevE.106.025102).
+
 1. Siegelman, L., Young, W. R., and Ingersoll, A. P. (2022). Polar vortex crystals: Emergence and structure _Proceedings of the National Academy of Sciences_, **119(17)**, e2120486119. doi:[10.1073/pnas.2120486119](https://doi.org/10.1073/pnas.2120486119).
 
 1. Dolce, M. and Drivas, T. D. (2022). On maximally mixed equilibria of two-dimensional perfect fluids. _Archive for Rational Mechanics and Analysis_, 2022, doi:[10.1007/s00205-022-01825-w](https://doi.org/10.1007/s00205-022-01825-w).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -92,7 +92,7 @@ The bibtex entry for the paper is:
 
 1. Bisits, J. I., Stanley G. J., and Zika, J. D. (2023). Can we accurately quantify a lateral diffusivity using a single tracer release? _Journal of Physical Oceanography_, **53(2)**, 647–659, doi:[10.1175/JPO-D-22-0145.1](https://doi.org/10.1175/JPO-D-22-0145.1).
 
-1. Parfenyev, V. (2022) Profile of a two-dimensional vortex condensate beyond the universal limit. *Phys. Rev. E*, **106**, 025102, doi:[10.1103/PhysRevE.106.025102](https://doi.org/10.1103/PhysRevE.106.025102).
+1. Parfenyev, V. (2022) Profile of a two-dimensional vortex condensate beyond the universal limit. _Phys. Rev. E_, **106**, 025102, doi:[10.1103/PhysRevE.106.025102](https://doi.org/10.1103/PhysRevE.106.025102).
 
 1. Siegelman, L., Young, W. R., and Ingersoll, A. P. (2022). Polar vortex crystals: Emergence and structure _Proceedings of the National Academy of Sciences_, **119(17)**, e2120486119. doi:[10.1073/pnas.2120486119](https://doi.org/10.1073/pnas.2120486119).
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -88,15 +88,15 @@ The bibtex entry for the paper is:
 
 1. Shokar, I. J. S., Kerswell, R. R., and Haynes, P. H. (2023) Stochastic latent transformer: Efficient modelling of stochastically forced zonal jets. arXiv preprint arXiv:2310.16741, doi:[10.48550/arXiv.2310.16741](https://doi.org/10.48550/arXiv.2310.16741).
 
-1. Siegelman, L. and Young, W. R. (2023). Two-dimensional turbulence above topography: Vortices and potential vorticity homogenization. _Proceedings of the National Academy of Sciences_, **120(44)**, e2308018120, doi:[10.1073/pnas.2308018120](https://doi.org/10.1073/pnas.2308018120).
+1. Siegelman, L. and Young, W. R. (2023). Two-dimensional turbulence above topography: Vortices and potential vorticity homogenization. _Proceedings of the National Academy of Sciences_, **120(44)**, e2308018120. doi:[10.1073/pnas.2308018120](https://doi.org/10.1073/pnas.2308018120).
 
 1. Bisits, J. I., Stanley G. J., and Zika, J. D. (2023). Can we accurately quantify a lateral diffusivity using a single tracer release? _Journal of Physical Oceanography_, **53(2)**, 647–659, doi:[10.1175/JPO-D-22-0145.1](https://doi.org/10.1175/JPO-D-22-0145.1).
 
 1. Parfenyev, V. (2022) Profile of a two-dimensional vortex condensate beyond the universal limit. _Phys. Rev. E_, **106**, 025102, doi:[10.1103/PhysRevE.106.025102](https://doi.org/10.1103/PhysRevE.106.025102).
 
-1. Siegelman, L., Young, W. R., and Ingersoll, A. P. (2022). Polar vortex crystals: Emergence and structure _Proceedings of the National Academy of Sciences_, **119(17)**, e2120486119. doi:[10.1073/pnas.2120486119](https://doi.org/10.1073/pnas.2120486119).
+1. Siegelman, L., Young, W. R., and Ingersoll, A. P. (2022). Polar vortex crystals: Emergence and structure _Proceedings of the National Academy of Sciences_, **119(17)**, e2120486119, doi:[10.1073/pnas.2120486119](https://doi.org/10.1073/pnas.2120486119).
 
-1. Dolce, M. and Drivas, T. D. (2022). On maximally mixed equilibria of two-dimensional perfect fluids. _Archive for Rational Mechanics and Analysis_, 2022, doi:[10.1007/s00205-022-01825-w](https://doi.org/10.1007/s00205-022-01825-w).
+1. Dolce, M. and Drivas, T. D. (2022). On maximally mixed equilibria of two-dimensional perfect fluids. _Archive for Rational Mechanics and Analysis_, **246**, 735–770, doi:[10.1007/s00205-022-01825-w](https://doi.org/10.1007/s00205-022-01825-w).
 
 1. Drivas, T. D. and Elgindi, T. M. (2022). Singularity formation in the incompressible Euler equation in finite and infinite time. arXiv preprint arXiv:2203.17221, doi:[10.48550/arXiv.2203.17221](https://doi.org/10.48550/arXiv.2203.17221).
 


### PR DESCRIPTION
This PR adds two papers by Parfenyev (2022, 2023) in the list of papers that use GeophysicalFlows.jl.
Also it homogenizes the style of the refs.

cc @parfenyev